### PR TITLE
Several minor fixes to get fedora-based build working

### DIFF
--- a/mkosi.conf.d/20-fedora/mkosi.extra/usr/lib/tmpfiles.d/etc-authselect.conf
+++ b/mkosi.conf.d/20-fedora/mkosi.extra/usr/lib/tmpfiles.d/etc-authselect.conf
@@ -1,0 +1,2 @@
+# Required by authselect
+L /etc/authselect

--- a/mkosi.extra/usr/lib/tmpfiles.d/etc.conf
+++ b/mkosi.extra/usr/lib/tmpfiles.d/etc.conf
@@ -17,7 +17,9 @@ L /etc/bash.bash_logout
 L /etc/ca-certificates
 L /etc/debuginfod
 L /etc/ssh/ssh_config
+L /etc/ssh/ssh_config.d
 L /etc/ssh/sshd_config
+L /etc/ssh/sshd_config.d
 # Canonical location to look for certificates
 L /etc/ssl
 # Required by pam environment plugin

--- a/mkosi.extra/usr/lib/tmpfiles.d/etc.conf
+++ b/mkosi.extra/usr/lib/tmpfiles.d/etc.conf
@@ -16,7 +16,8 @@ L /etc/bash.bash_logout
 # Canonical location to look for certificates
 L /etc/ca-certificates
 L /etc/debuginfod
-L /etc/ssh
+L /etc/ssh/ssh_config
+L /etc/ssh/sshd_config
 # Canonical location to look for certificates
 L /etc/ssl
 # Required by pam environment plugin

--- a/mkosi.postinst.chroot
+++ b/mkosi.postinst.chroot
@@ -24,5 +24,5 @@ if [[ -d /etc/pam.d ]]; then
 fi
 
 # Get rid of obsolete stuff in the pam stack.
-sed --in-place '/pam_shells.so/d' /usr/lib/pam.d/system-login
-sed --in-place '/pam_securetty.so/d' /usr/lib/pam.d/remote
+[[ -f /usr/lib/pam.d/system-login ]] && sed --in-place '/pam_shells.so/d' /usr/lib/pam.d/system-login
+[[ -f /usr/lib/pam.d/remote ]] && sed --in-place '/pam_securetty.so/d' /usr/lib/pam.d/remote


### PR DESCRIPTION
Minor commits to add/adjust tmpfiles.d symlinks under `/etc`, and to restrict the sed file modification in `mkosi.postinst.chroot` to only run if the files exist.