### PR TITLE
Conditionalize more tmpfiles entries

### DIFF
--- a/mkosi.extra/usr/lib/tmpfiles.d/etc.conf
+++ b/mkosi.extra/usr/lib/tmpfiles.d/etc.conf
@@ -11,10 +11,12 @@ L /etc/issue
 L /etc/profile
 # Required by pam_env plugin
 L /etc/security
-L /etc/bash.bashrc
-L /etc/bash.bash_logout
+L? /etc/bashrc
+L? /etc/bash.bashrc
+L? /etc/bash.bash_logout
 # Canonical location to look for certificates
-L /etc/ca-certificates
+L? /etc/ca-certificates
+L? /etc/pki
 L /etc/debuginfod
 L /etc/ssh/ssh_config
 L /etc/ssh/ssh_config.d


### PR DESCRIPTION
These are different between Arch and Fedora so make them both conditional.