### PR TITLE
Add crypto-policies to tmpfiles

### DIFF
--- a/mkosi.extra/usr/lib/tmpfiles.d/etc.conf
+++ b/mkosi.extra/usr/lib/tmpfiles.d/etc.conf
@@ -16,6 +16,7 @@ L? /etc/bash.bashrc
 L? /etc/bash.bash_logout
 # Canonical location to look for certificates
 L? /etc/ca-certificates
+L? /etc/crypto-policies
 L? /etc/pki
 L /etc/debuginfod
 L /etc/ssh/ssh_config


### PR DESCRIPTION
Among other things, this is needed for `systemd-resolved` to work on Fedora.