### PR TITLE
Fix ordering cycle between preset-global.service and basic.target

### DIFF
--- a/mkosi.extra/usr/lib/systemd/system-preset/10-particleos.preset
+++ b/mkosi.extra/usr/lib/systemd/system-preset/10-particleos.preset
@@ -20,6 +20,3 @@ disable avahi.*
 
 enable pcscd.service
 enable power-profiles-daemon.service
-
-# Our own service to run systemctl preset --global.
-enable preset-global.service

--- a/mkosi.extra/usr/lib/systemd/system/preset-global.service
+++ b/mkosi.extra/usr/lib/systemd/system/preset-global.service
@@ -1,9 +1,14 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 [Unit]
-Before=user.slice
 ConditionFirstBoot=yes
 ConditionPathIsReadWrite=/etc
+
+DefaultDependencies=no
+
+Before=basic.target
+Conflicts=shutdown.target
+Before=shutdown.target
 
 [Service]
 Type=oneshot
@@ -11,4 +16,4 @@ RemainAfterExit=yes
 ExecStart=systemctl preset-all --global
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=basic.target


### PR DESCRIPTION
`preset-global.service` was never run, which resulted in user presets never getting created. Wire it up to sysinit to ensure it's run and fix its dependencies while at it.