### PR TITLE
fixup: Fix ordering cycle between preset-global.service and basic.target

### DIFF
--- a/mkosi.extra/usr/lib/systemd/system-preset/10-particleos.preset
+++ b/mkosi.extra/usr/lib/systemd/system-preset/10-particleos.preset
@@ -20,3 +20,6 @@ disable avahi.*
 
 enable pcscd.service
 enable power-profiles-daemon.service
+
+# Our own service to run systemctl preset --global.
+enable preset-global.service


### PR DESCRIPTION
Restore accidentally dropped preset, fixup for #9 