### PR TITLE
Add netesp profile to build a netesp image

### DIFF
--- a/mkosi.images/netesp/mkosi.conf
+++ b/mkosi.images/netesp/mkosi.conf
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Profiles=netesp
+
+[Output]
+Format=esp
+OutputExtension=raw.img
+ImageVersion=

--- a/mkosi.images/netesp/mkosi.conf.d/arch.conf
+++ b/mkosi.images/netesp/mkosi.conf.d/arch.conf
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=arch
+
+[Content]
+Packages=systemd

--- a/mkosi.images/netesp/mkosi.conf.d/fedora.conf
+++ b/mkosi.images/netesp/mkosi.conf.d/fedora.conf
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=fedora
+
+[Content]
+Packages=systemd-boot


### PR DESCRIPTION
The netesp image is a disk image with the .raw.img extension and only has a bootloader in it. We can later add a postinst script to populate the image with type#1 bootloader entries that will download UKIs over the network.