### PR TITLE
working netsp support

### DIFF
--- a/mkosi.images/netesp/mkosi.conf
+++ b/mkosi.images/netesp/mkosi.conf
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Profiles=netesp
+
+[Output]
+Format=esp
+# UEFI insists on the .img suffix for disk images to boot from, hence let's combine our usual suffix with UEFI's
+OutputExtension=raw.img
+ImageVersion=
+
+[Content]
+Bootable=yes

--- a/mkosi.images/netesp/mkosi.conf.d/arch.conf
+++ b/mkosi.images/netesp/mkosi.conf.d/arch.conf
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=arch
+
+[Content]
+Packages=systemd

--- a/mkosi.images/netesp/mkosi.conf.d/fedora.conf
+++ b/mkosi.images/netesp/mkosi.conf.d/fedora.conf
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=fedora
+
+[Content]
+Packages=systemd-boot

--- a/mkosi.images/netesp/mkosi.extra/efi/loader/entries/90-debian-particleos-obs-current.conf
+++ b/mkosi.images/netesp/mkosi.extra/efi/loader/entries/90-debian-particleos-obs-current.conf
@@ -1,0 +1,3 @@
+title Debian ParticleOS Current from OBS (Network Boot)
+architecture x64
+uki-url http://downloadcontentcdn.opensuse.org/repositories/home:/bluca:/branches:/home:/bluca:/systemd/Debian_Testing_images/ParticleOS-x86-64.efi

--- a/mkosi.images/netesp/mkosi.extra/efi/loader/loader.conf
+++ b/mkosi.images/netesp/mkosi.extra/efi/loader/loader.conf
@@ -1,0 +1,1 @@
+timeout 7


### PR DESCRIPTION
This makes #20 work.

Also adds a commit on top, which adds a menu entry pointing to @bluca's Debian ParticleOS build.

You can build this and then run `systemd-vmspawn -n --register=no -i mkosi.build/netesp.img.raw` and it works beautifully. Will use network for getting the UKI (i.e. stage 2), but not for the netesp (stage 1). That can be made work too, but is more complicated: just boot any regular mkosi image one can log into and do `kernel-bootcfg --add-url=… --title=foobar --once && reboot` pointing it to a http url with the netesp image, and it will then go through the full chain: state 1 and stage 2 both acquired via http.