### PR TITLE
mkosi: set host name to "particle"

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -25,6 +25,7 @@ KernelCommandLine=
 InitrdProfiles=
 KernelModulesInitrdExclude=.*
 KernelModulesInitrdInclude=default
+Hostname=particle
 
 Packages=
         acl


### PR DESCRIPTION
Let's make visible what this is, and name the hosts "particle"