### PR TITLE
enforce image policy

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,6 +1,5 @@
 posted:
 • homed adopt
-• image policy
 • hostnamectl should show image id
 
 todo:

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -22,6 +22,7 @@ UnifiedKernelImageFormat=%i_%v_%a
 KernelCommandLine=
         rw
         audit=0
+        systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=verity:root=encrypted:swap=encrypted+unused+absent:home=unprotected:=ignore
 InitrdProfiles=
 KernelModulesInitrdExclude=.*
 KernelModulesInitrdInclude=default

--- a/mkosi.uki-profiles/10-live.conf
+++ b/mkosi.uki-profiles/10-live.conf
@@ -17,5 +17,6 @@ Cmdline=
         systemd.journald.max_level_console=warning
         rw
         audit=0
+        systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=verity:=ignore
 
 SignExpectedPcr=no

--- a/mkosi.uki-profiles/80-storagetm.conf
+++ b/mkosi.uki-profiles/80-storagetm.conf
@@ -10,5 +10,6 @@ Cmdline=
         ip=any
         ro
         audit=0
+        systemd.image_policy=-
 
 SignExpectedPcr=no

--- a/mkosi.uki-profiles/90-factory-reset.conf
+++ b/mkosi.uki-profiles/90-factory-reset.conf
@@ -9,5 +9,6 @@ Cmdline=
         systemd.factory_reset=1
         rw
         audit=0
+        systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=verity:root=encrypted:swap=encrypted+unused+absent:home=unprotected:=ignore
 
 SignExpectedPcr=yes

--- a/mkosi.uki-profiles/91-factory-reset-with-tpm-clear.conf
+++ b/mkosi.uki-profiles/91-factory-reset-with-tpm-clear.conf
@@ -9,5 +9,6 @@ Cmdline=
         rd.systemd.unit=factory-reset.target
         ro
         audit=0
+        systemd.image_policy=-
 
 SignExpectedPcr=no

--- a/mkosi.uki-profiles/95-emergency.conf
+++ b/mkosi.uki-profiles/95-emergency.conf
@@ -9,5 +9,6 @@ Cmdline=
         systemd.unit=emergency.target
         rw
         audit=0
+        systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=verity:root=encrypted:swap=encrypted+unused+absent:home=unprotected:=ignore
 
 SignExpectedPcr=yes

--- a/mkosi.uki-profiles/99-debug.conf
+++ b/mkosi.uki-profiles/99-debug.conf
@@ -11,5 +11,6 @@ Cmdline=
         systemd.journald.forward_to_console=1
         rw
         audit=0
+        systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=verity:root=encrypted:swap=encrypted+unused+absent:home=unprotected:=ignore
 
 SignExpectedPcr=yes


### PR DESCRIPTION
91-factory-reset-with-tpm-clear.conf + 80-storagetm.conf → disallow all use of the various partitions

default + 90-factory-reset.conf + 95-emergency.conf + 99-debug.conf → require verity on usr, require encryption on root fs, mount home, use swap, ignore rest

10-live.conf → require verity on usr, ignore rest