### PR TITLE
mkosi: tweak default hostname choice

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -25,7 +25,7 @@ KernelCommandLine=
 InitrdProfiles=
 KernelModulesInitrdExclude=.*
 KernelModulesInitrdInclude=default
-Hostname=particle
+Hostname=particle-????-????
 
 Packages=
         acl


### PR DESCRIPTION
This depends on https://github.com/systemd/systemd/pull/36647

This gives every instance of ParticleOS a slightly different hostname (well, within the bounds of 2^32), which is quite useful when operating with a number of them.