### PR TITLE
image-policy: tighten policy, insist on signing

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -22,7 +22,7 @@ UnifiedKernelImageFormat=%i_%v_%a
 KernelCommandLine=
         rw
         audit=0
-        systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=verity:root=encrypted:swap=encrypted+unused+absent:home=unprotected:=ignore
+        systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:root=encrypted:swap=encrypted+unused+absent:home=unprotected:=ignore
 InitrdProfiles=
 KernelModulesInitrdExclude=.*
 KernelModulesInitrdInclude=default

--- a/mkosi.uki-profiles/10-live.conf
+++ b/mkosi.uki-profiles/10-live.conf
@@ -17,6 +17,6 @@ Cmdline=
         systemd.journald.max_level_console=warning
         rw
         audit=0
-        systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=verity:=ignore
+        systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:=ignore
 
 SignExpectedPcr=no

--- a/mkosi.uki-profiles/90-factory-reset.conf
+++ b/mkosi.uki-profiles/90-factory-reset.conf
@@ -9,6 +9,6 @@ Cmdline=
         systemd.factory_reset=1
         rw
         audit=0
-        systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=verity:root=encrypted:swap=encrypted+unused+absent:home=unprotected:=ignore
+        systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:root=encrypted:swap=encrypted+unused+absent:home=unprotected:=ignore
 
 SignExpectedPcr=yes

--- a/mkosi.uki-profiles/95-emergency.conf
+++ b/mkosi.uki-profiles/95-emergency.conf
@@ -9,6 +9,6 @@ Cmdline=
         systemd.unit=emergency.target
         rw
         audit=0
-        systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=verity:root=encrypted:swap=encrypted+unused+absent:home=unprotected:=ignore
+        systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:root=encrypted:swap=encrypted+unused+absent:home=unprotected:=ignore
 
 SignExpectedPcr=yes

--- a/mkosi.uki-profiles/99-debug.conf
+++ b/mkosi.uki-profiles/99-debug.conf
@@ -11,6 +11,6 @@ Cmdline=
         systemd.journald.forward_to_console=1
         rw
         audit=0
-        systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=verity:root=encrypted:swap=encrypted+unused+absent:home=unprotected:=ignore
+        systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:root=encrypted:swap=encrypted+unused+absent:home=unprotected:=ignore
 
 SignExpectedPcr=yes


### PR DESCRIPTION
Let's make the image policy stricter: we want to require signed veritfy, not just plain verity logic when we dissect the root fs.

Note that currently this part of the image policy is not enforced either way, but this is going to change soon (I hope).

Follow-up for: 03569f9f85ea45cf1176b6e3d78916ffffcc8e73