### PR TITLE
repart: include image name in home/swap/root

### DIFF
--- a/mkosi.extra/usr/lib/repart.d/30-swap.conf
+++ b/mkosi.extra/usr/lib/repart.d/30-swap.conf
@@ -7,3 +7,4 @@ SizeMinBytes=4G
 SizeMaxBytes=4G
 Encrypt=tpm2
 FactoryReset=yes
+Label=%M-swap

--- a/mkosi.extra/usr/lib/repart.d/40-root.conf
+++ b/mkosi.extra/usr/lib/repart.d/40-root.conf
@@ -9,3 +9,4 @@ Subvolumes=/var
 MakeDirectories=/var/log/journal
 Encrypt=tpm2
 FactoryReset=yes
+Label=%M-root

--- a/mkosi.extra/usr/lib/repart.d/50-home.conf
+++ b/mkosi.extra/usr/lib/repart.d/50-home.conf
@@ -6,3 +6,4 @@ Format=btrfs
 SizeMinBytes=1G
 Weight=40000
 FactoryReset=yes
+Label=%M-home


### PR DESCRIPTION
Let's associate these directories with our image. In a world where these partitions are TPM locked it really matters we unlock them with the right OS, because unlocking is unlikely to be possible on other images since their PCRs won't match.

This is just preparation for an unknown, bright future. I have nothing in petto that would actually care about the names at this point.