### PR TITLE
switch to "root=dissect"

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -25,6 +25,7 @@ KernelCommandLine=
         rw
         audit=0
         systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:root=encrypted+absent:swap=encrypted+unused+absent:home=unprotected+absent:=ignore
+        systemd.image_filter=usr=ParticleOS_*:usr-verity=ParticleOS_*:usr-verity-sig=ParticleOS_*:root=ParticleOS-*:swap=ParticleOS-*:home=ParticleOS-*
 InitrdProfiles=
 KernelModulesInitrdExclude=.*
 KernelModulesInitrdInclude=default

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -20,9 +20,11 @@ Output=%i_%v_%a
 [Content]
 UnifiedKernelImageFormat=%i_%v_%a
 KernelCommandLine=
+        root=dissect
+        mount.usr=dissect
         rw
         audit=0
-        systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:root=encrypted:swap=encrypted+unused+absent:home=unprotected:=ignore
+        systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:root=encrypted+absent:swap=encrypted+unused+absent:home=unprotected+absent:=ignore
 InitrdProfiles=
 KernelModulesInitrdExclude=.*
 KernelModulesInitrdInclude=default

--- a/mkosi.uki-profiles/10-live.conf
+++ b/mkosi.uki-profiles/10-live.conf
@@ -7,6 +7,7 @@ Profile=
 
 Cmdline=
         root=tmpfs
+        mount.usr=dissect
         rd.systemd.mask=systemd-repart.service
         systemd.mask=systemd-repart.service
         systemd.firstboot=no

--- a/mkosi.uki-profiles/10-live.conf
+++ b/mkosi.uki-profiles/10-live.conf
@@ -19,5 +19,6 @@ Cmdline=
         rw
         audit=0
         systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:=ignore
+        systemd.image_filter=usr=ParticleOS_*:usr-verity=ParticleOS_*:usr-verity-sig=ParticleOS_*
 
 SignExpectedPcr=no

--- a/mkosi.uki-profiles/80-storagetm.conf
+++ b/mkosi.uki-profiles/80-storagetm.conf
@@ -11,5 +11,6 @@ Cmdline=
         ro
         audit=0
         systemd.image_policy=-
+        root=off
 
 SignExpectedPcr=no

--- a/mkosi.uki-profiles/90-factory-reset.conf
+++ b/mkosi.uki-profiles/90-factory-reset.conf
@@ -12,5 +12,6 @@ Cmdline=
         rw
         audit=0
         systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:root=encrypted+absent:swap=encrypted+unused+absent:home=unprotected+absent:=ignore
+        systemd.image_filter=usr=ParticleOS_*:usr-verity=ParticleOS_*:usr-verity-sig=ParticleOS_*:root=ParticleOS-*:swap=ParticleOS-*:home=ParticleOS-*
 
 SignExpectedPcr=yes

--- a/mkosi.uki-profiles/90-factory-reset.conf
+++ b/mkosi.uki-profiles/90-factory-reset.conf
@@ -6,9 +6,11 @@ Profile=
         TITLE=Reset System to Factory Defaults [CAUTION!]
 
 Cmdline=
+        root=dissect
+        mount.usr=dissect
         systemd.factory_reset=1
         rw
         audit=0
-        systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:root=encrypted:swap=encrypted+unused+absent:home=unprotected:=ignore
+        systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:root=encrypted+absent:swap=encrypted+unused+absent:home=unprotected+absent:=ignore
 
 SignExpectedPcr=yes

--- a/mkosi.uki-profiles/91-factory-reset-with-tpm-clear.conf
+++ b/mkosi.uki-profiles/91-factory-reset-with-tpm-clear.conf
@@ -10,5 +10,6 @@ Cmdline=
         ro
         audit=0
         systemd.image_policy=-
+        root=off
 
 SignExpectedPcr=no

--- a/mkosi.uki-profiles/95-emergency.conf
+++ b/mkosi.uki-profiles/95-emergency.conf
@@ -12,5 +12,6 @@ Cmdline=
         rw
         audit=0
         systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:root=encrypted+absent:swap=encrypted+unused+absent:home=unprotected+absent:=ignore
+        systemd.image_filter=usr=ParticleOS_*:usr-verity=ParticleOS_*:usr-verity-sig=ParticleOS_*:root=ParticleOS-*:swap=ParticleOS-*:home=ParticleOS-*
 
 SignExpectedPcr=yes

--- a/mkosi.uki-profiles/95-emergency.conf
+++ b/mkosi.uki-profiles/95-emergency.conf
@@ -6,9 +6,11 @@ Profile=
         TITLE=Boot into Emergency Mode
 
 Cmdline=
+        root=dissect
+        mount.usr=dissect
         systemd.unit=emergency.target
         rw
         audit=0
-        systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:root=encrypted:swap=encrypted+unused+absent:home=unprotected:=ignore
+        systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:root=encrypted+absent:swap=encrypted+unused+absent:home=unprotected+absent:=ignore
 
 SignExpectedPcr=yes

--- a/mkosi.uki-profiles/99-debug.conf
+++ b/mkosi.uki-profiles/99-debug.conf
@@ -16,4 +16,8 @@ Cmdline=
         systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:root=encrypted+absent:swap=encrypted+unused+absent:home=unprotected+absent:=ignore
         systemd.image_filter=usr=ParticleOS_*:usr-verity=ParticleOS_*:usr-verity-sig=ParticleOS_*:root=ParticleOS-*:swap=ParticleOS-*:home=ParticleOS-*
 
+# More knobs to enable:
+#       systemd.log_target=console
+#       rd.systemd.break=pre-switch-root
+
 SignExpectedPcr=yes

--- a/mkosi.uki-profiles/99-debug.conf
+++ b/mkosi.uki-profiles/99-debug.conf
@@ -14,5 +14,6 @@ Cmdline=
         rw
         audit=0
         systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:root=encrypted+absent:swap=encrypted+unused+absent:home=unprotected+absent:=ignore
+        systemd.image_filter=usr=ParticleOS_*:usr-verity=ParticleOS_*:usr-verity-sig=ParticleOS_*:root=ParticleOS-*:swap=ParticleOS-*:home=ParticleOS-*
 
 SignExpectedPcr=yes

--- a/mkosi.uki-profiles/99-debug.conf
+++ b/mkosi.uki-profiles/99-debug.conf
@@ -6,11 +6,13 @@ Profile=
         TITLE=Boot with debug logs enabled
 
 Cmdline=
+        root=dissect
+        mount.usr=dissect
         debug
         systemd.log_level=debug
         systemd.journald.forward_to_console=1
         rw
         audit=0
-        systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:root=encrypted:swap=encrypted+unused+absent:home=unprotected:=ignore
+        systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:root=encrypted+absent:swap=encrypted+unused+absent:home=unprotected+absent:=ignore
 
 SignExpectedPcr=yes


### PR DESCRIPTION
This is a companion to https://github.com/systemd/systemd/pull/36631, and switch particleos over to mounting the root fs via the dissection logic, i.e. taking the image policy into account.