### PR TITLE
fedora: enable color prompt

### DIFF
--- a/mkosi.conf.d/20-fedora/mkosi.conf
+++ b/mkosi.conf.d/20-fedora/mkosi.conf
@@ -8,6 +8,7 @@ Release=rawhide
 
 [Content]
 Packages=
+        bash-color-prompt
         bpftool
         cryptsetup
         distribution-gpg-keys


### PR DESCRIPTION
This package will turn on color shell prompt support on Fedora. It has been a default thing in Fedora for a while. Lennart likes color, so let's just enable it by default.

(Note that this doesn't quite work via serial/hypervisor ttys yet, needs util-linux support:
https://github.com/util-linux/util-linux/issues/3463 – but it does work via ssh)