### PR TITLE
add OBS systemd for Fedora 41

### DIFF
--- a/mkosi.profiles/obs/fedora-41.repo
+++ b/mkosi.profiles/obs/fedora-41.repo
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[system_systemd]
+name=systemd packages built from upstream main (Fedora_41)
+type=rpm-md
+baseurl=https://download.opensuse.org/repositories/system:/systemd/Fedora_41/
+gpgcheck=1
+gpgkey=https://download.opensuse.org/repositories/system:/systemd/Fedora_41/repodata/repomd.xml.key
+enabled=1

--- a/mkosi.profiles/obs/mkosi.conf.d/fedora-41-tools.conf
+++ b/mkosi.profiles/obs/mkosi.conf.d/fedora-41-tools.conf
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+ToolsTreeDistribution=fedora
+ToolsTreeRelease=41
+
+[Build]
+ToolsTreeSandboxTrees=fedora-41.repo:/etc/yum.repos.d/systemd.repo

--- a/mkosi.profiles/obs/mkosi.conf.d/fedora-41.conf
+++ b/mkosi.profiles/obs/mkosi.conf.d/fedora-41.conf
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=fedora
+Release=41
+
+[Build]
+SandboxTrees=fedora-41.repo:/etc/yum.repos.d/systemd.repo


### PR DESCRIPTION
Honestly I have no clue what's the difference between the `ToolsTree` and normal `Sandbox` but mine appears to be doing some stuff with the `ToolsTree` being based off Fedora Rawhide and `Sandbox` off Fedora 41.

Should they be in sync? Well the final product boots fine at least for now. Onwards to seeing if I can get ZFS rolling on it.

This makes my build work at least - resolving https://github.com/systemd/particleos/issues/46.