### PR TITLE
Revert "Temporarily mask systemd-validatefs@.service"

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -26,8 +26,6 @@ KernelCommandLine=
         audit=0
         systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:root=encrypted+absent:swap=encrypted+unused+absent:home=unprotected+absent:=ignore
         systemd.image_filter=usr=ParticleOS_*:usr-verity=ParticleOS_*:usr-verity-sig=ParticleOS_*:root=ParticleOS-*:swap=ParticleOS-*:home=ParticleOS-*
-        systemd.mask=systemd-validatefs@sysroot-usr.service
-        rd.systemd.mask=systemd-validatefs@sysroot-usr.service
 InitrdProfiles=
 KernelInitrdModules=default
 Hostname=particle-????-????


### PR DESCRIPTION
The issue is fixed in main:

https://github.com/systemd/systemd/pull/37434

This reverts commit 05aa606c542318892a7307da1d42ce14c1e6cf55.