### PR TITLE
repart: also use CopyBlocks= for verity signature data

### DIFF
--- a/mkosi.extra/usr/lib/repart.d/10-usr-verity-sig.conf
+++ b/mkosi.extra/usr/lib/repart.d/10-usr-verity-sig.conf
@@ -3,3 +3,4 @@
 [Partition]
 Type=usr-verity-sig
 Label=%M_%A_verity_sig
+CopyBlocks=auto


### PR DESCRIPTION
Relies on https://github.com/systemd/systemd/pull/37704 being merged.