### PR TITLE
repart: use CopyFiles= instead of CopyBlocks= for ESP

### DIFF
--- a/mkosi.extra/usr/lib/repart.d/00-esp.conf
+++ b/mkosi.extra/usr/lib/repart.d/00-esp.conf
@@ -2,4 +2,7 @@
 
 [Partition]
 Type=esp
-CopyBlocks=auto
+Format=vfat
+CopyFiles=/boot:/
+SizeMinBytes=1G
+SizeMaxBytes=1G


### PR DESCRIPTION
CopyBlocks copies the UUID, which has to be unique per ESP, as it is used to discover the GPT disk that we booted from