### PR TITLE
Enable wired interfaces by default in networkd, disable in desktop profile

### DIFF
--- a/mkosi.extra/usr/lib/systemd/network/89-ethernet.network
+++ b/mkosi.extra/usr/lib/systemd/network/89-ethernet.network
@@ -1,0 +1,1 @@
+89-ethernet.network.example

--- a/mkosi.extra/usr/lib/systemd/system-preset/10-particleos.preset
+++ b/mkosi.extra/usr/lib/systemd/system-preset/10-particleos.preset
@@ -2,6 +2,7 @@
 
 # Make sure we have networking available.
 enable systemd-networkd.service
+enable systemd-networkd.socket
 enable systemd-networkd-wait-online.service
 enable systemd-resolved.service
 

--- a/mkosi.profiles/desktop/mkosi.conf
+++ b/mkosi.profiles/desktop/mkosi.conf
@@ -6,3 +6,6 @@ Packages=
         pipewire
         pipewire-alsa
         xdg-desktop-portal
+
+# NetworkManager is used in the desktop profiles
+RemoveFiles=/usr/lib/systemd/network/89-ethernet.network


### PR DESCRIPTION
Ensure we get networking by default in the minimal image by enabling networkd's config.
Given it now conflicts with NetworManager, disable networkd in the desktop profile via presets.