### PR TITLE
Configure zram

### DIFF
--- a/mkosi.conf.d/arch/mkosi.conf
+++ b/mkosi.conf.d/arch/mkosi.conf
@@ -33,6 +33,7 @@ Packages=
         tpm2-tools
         tpm2-tss
         vim-minimal
+        zram-generator
 
 VolatilePackages=
         systemd-ukify

--- a/mkosi.conf.d/arch/mkosi.extra/usr/lib/systemd/zram-generator.conf
+++ b/mkosi.conf.d/arch/mkosi.extra/usr/lib/systemd/zram-generator.conf
@@ -1,0 +1,2 @@
+[zram0]
+#zram-size = min(ram / 2, 4096)

--- a/mkosi.conf.d/debian/mkosi.conf
+++ b/mkosi.conf.d/debian/mkosi.conf
@@ -47,6 +47,7 @@ Packages=
         systemd-sysv
         systemd-timesyncd
         systemd-ukify
+        systemd-zram-generator
         tpm2-tools
 
 VolatilePackages=

--- a/mkosi.conf.d/debian/mkosi.extra/usr/lib/systemd/zram-generator.conf
+++ b/mkosi.conf.d/debian/mkosi.extra/usr/lib/systemd/zram-generator.conf
@@ -1,0 +1,2 @@
+[zram0]
+#zram-size = min(ram / 2, 4096)

--- a/mkosi.conf.d/fedora/mkosi.conf
+++ b/mkosi.conf.d/fedora/mkosi.conf
@@ -46,6 +46,7 @@ Packages=
         tpm2-tss
         veritysetup
         vim-minimal
+        zram-generator-defaults
 
 VolatilePackages=
         systemd-boot


### PR DESCRIPTION
Pretty simple change which adds zram-generator with default settings. 

Builds and properly configures zram on Arch and Fedora. 
Builds on debian, but I cannot seem to boot debian images with mkosi vm, so could not test if zram was properly configured. 

```
[particleos@particle-7802-1a83 ~]$ swapon
NAME       TYPE      SIZE USED PRIO
/dev/zram0 partition 1.9G   0B  100
/dev/dm-2  partition   4G   0B   -2

[particleos@particle-7802-1a83 ~]$ free -h
               total        used        free      shared  buff/cache   available
Mem:           3.8Gi       411Mi       3.4Gi       992Ki       259Mi       3.4Gi
Swap:          5.9Gi          0B       5.9Gi

[particleos@particle-7802-1a83 ~]$ zramctl 
NAME       ALGORITHM DISKSIZE DATA COMPR TOTAL STREAMS MOUNTPOINT
/dev/zram0 zstd          1.9G   4K   64B   20K         [SWAP]

```