### PR TITLE
Fix relative symlinks to /usr

### DIFF
--- a/mkosi.finalize
+++ b/mkosi.finalize
@@ -6,3 +6,4 @@ set -e
 # systemd-tmpfiles to symlink individual directories from it to /etc.
 mkdir -p "$BUILDROOT/usr/share/factory/"
 cp --archive --no-target-directory --update=none "$BUILDROOT/etc" "$BUILDROOT/usr/share/factory/etc"
+ln -s /usr "$BUILDROOT/usr/share/factory/usr"


### PR DESCRIPTION
Some config files are relative links to /usr, like `20-systemd-ssh-proxy.conf` (in `/etc/ssh/ssh_config.d`) linked to `../../../usr/lib/systemd/ssh_config.d/20-systemd-ssh-proxy.conf`, probably because [`LIBEXECDIR`](https://github.com/systemd/systemd/blob/dbe13de11c63b97b50df3a4dd374b9bb856eaa21/tmpfiles.d/20-systemd-ssh-generator.conf.in#L11)

And `/etc/ssh/ssh_config` [is set with a symlink](https://github.com/systemd/particleos/blob/ba7cc16cc7569883da74ac8518ea4440cd4f9599/mkosi.extra/usr/lib/tmpfiles.d/etc.conf#L23) here

It leads to a broken link:

```console
$ file /etc/ssh/ssh_config.d/20-systemd-ssh-proxy.conf
/etc/ssh/ssh_config.d/20-systemd-ssh-proxy.conf: broken symbolic link to ../../../usr/lib/systemd/ssh_config.d/20-systemd-ssh-proxy.conf
```

These relative links are broken in /usr/share/factory/etc unless /usr is linked to /usr/share/factory/usr