### PR TITLE
gnome: add workaround for accountsservices and enable gnome-initial-setup

### DIFF
--- a/mkosi.profiles/gnome/mkosi.conf.d/debian/mkosi.conf
+++ b/mkosi.profiles/gnome/mkosi.conf.d/debian/mkosi.conf
@@ -7,8 +7,7 @@ Distribution=debian
 Packages=
         gnome-browser-connector
         gnome-core
-        # TODO: enable when it integrates with homed
-        # gnome-initial-setup
+        gnome-initial-setup
         gnome-keyring-pkcs11
         gnome-session-xsession
         gnome-software-plugin-flatpak

--- a/mkosi.profiles/gnome/mkosi.extra/usr/lib/systemd/system/homed-accounts-workaround.service
+++ b/mkosi.profiles/gnome/mkosi.extra/usr/lib/systemd/system/homed-accounts-workaround.service
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# TODO: drop once https://gitlab.freedesktop.org/accountsservice/accountsservice/-/issues/89 is fixed
+
+[Unit]
+Description=Tell the accounts service about homed users
+After=systemd-homed.service accounts-daemon.service
+Before=systemd-user-sessions.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c "for n in $$(busctl call org.freedesktop.home1 /org/freedesktop/home1 org.freedesktop.home1.Manager ListHomes --json=pretty | jq -r '.data.[].[].[0]'); do busctl call org.freedesktop.Accounts /org/freedesktop/Accounts org.freedesktop.Accounts CacheUser s $$n; done"
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Needed until https://gitlab.freedesktop.org/accountsservice/accountsservice/-/issues/89 is fixed to let GNOME know that homed users exist and there's no need to run the initial user setup.
Install the initial setup package so that if someone doesn't create a user ahead of time there's a nice GUI for it.