### PR TITLE
debian: drop debian-specific pam.d line from tmpfiles.d

### DIFF
--- a/mkosi.conf.d/debian/mkosi.postinst.chroot
+++ b/mkosi.conf.d/debian/mkosi.postinst.chroot
@@ -1,0 +1,9 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+set -e
+
+# Debian/Ubuntu PAM patches break /usr/lib/pam.d/ so copy to factory
+# TODO: drop after https://salsa.debian.org/vorlon/pam/-/merge_requests/26 is merged
+if [[ -f /usr/lib/tmpfiles.d/debian.conf ]]; then
+    sed -i '/\/etc\/pam.d/d' /usr/lib/tmpfiles.d/debian.conf
+fi


### PR DESCRIPTION
On Debian there are custom patches that break /usr/lib/pam.d/ so login doesn't work:

Aug 28 17:52:55 particle-6579-bbfd login[1260]: PAM _pam_load_conf_file: unable to open config for /etc/pam.d/common-auth
Aug 28 17:52:55 particle-6579-bbfd login[1261]: PAM _pam_load_conf_file: unable to open config for /etc/pam.d/common-auth
Aug 28 17:52:55 particle-6579-bbfd login[1260]: PAM error loading (null)
Aug 28 17:52:55 particle-6579-bbfd login[1261]: PAM error loading (null)
Aug 28 17:52:55 particle-6579-bbfd login[1260]: PAM _pam_init_handlers: error reading /usr/lib/pam.d/login
Aug 28 17:52:55 particle-6579-bbfd login[1261]: PAM _pam_init_handlers: error reading /usr/lib/pam.d/login
Aug 28 17:52:55 particle-6579-bbfd login[1261]: PAM _pam_init_handlers: [Critical error - immediate abort]
Aug 28 17:52:55 particle-6579-bbfd login[1260]: PAM _pam_init_handlers: [Critical error - immediate abort]
Aug 28 17:52:55 particle-6579-bbfd login[1261]: PAM error reading PAM configuration file
Aug 28 17:52:55 particle-6579-bbfd login[1260]: PAM error reading PAM configuration file
Aug 28 17:52:55 particle-6579-bbfd login[1261]: PAM pam_start: failed to initialize handlers
Aug 28 17:52:55 particle-6579-bbfd login[1260]: PAM pam_start: failed to initialize handlers
Aug 28 17:52:55 particle-6579-bbfd login[1260]: Couldn't initialize PAM: Critical error - immediate abort
Aug 28 17:52:55 particle-6579-bbfd login[1261]: Couldn't initialize PAM: Critical error - immediate abort

There's a custom particleos tmpfiles.d with the line:

L? /etc/pam.d - - - - /usr/lib/pam.d

But this conflicts with systemd's:

C! /etc/pam.d - - - -

Edit it out to let the particleos one do its thing