### PR TITLE
UKI: add kernel command line and initrd modules for Plymouth

### DIFF
--- a/mkosi.profiles/desktop/mkosi.conf
+++ b/mkosi.profiles/desktop/mkosi.conf
@@ -15,3 +15,9 @@ Packages=
 
 # NetworkManager is used in the desktop profiles
 RemoveFiles=/usr/lib/systemd/network/89-ethernet.network
+
+KernelCommandLine=plymouth.use-simpledrm splash
+
+KernelInitrdModules=/drivers/gpu/drm
+
+InitrdProfiles=plymouth


### PR DESCRIPTION
With simpledrm the UKI can show the Plymouth splash screen immediately. Add the filter for the modules and the kernel cmdline to the desktop profile.