### PR TITLE
UKI: update remote images

### DIFF
--- a/mkosi.images/netesp/mkosi.extra/efi/loader/entries/90-debian-13-particleos-obs-current.conf
+++ b/mkosi.images/netesp/mkosi.extra/efi/loader/entries/90-debian-13-particleos-obs-current.conf
@@ -1,0 +1,3 @@
+title Debian 13 ParticleOS Current from OBS (Network Boot)
+architecture x64
+uki-url http://downloadcontentcdn.opensuse.org/repositories/system:/systemd/debian_13_images/ParticleOS_x86-64.efi

--- a/mkosi.images/netesp/mkosi.extra/efi/loader/entries/90-debian-particleos-obs-current.conf
+++ b/mkosi.images/netesp/mkosi.extra/efi/loader/entries/90-debian-particleos-obs-current.conf
@@ -1,3 +1,0 @@
-title Debian Testing ParticleOS Current from OBS (Network Boot)
-architecture x64
-uki-url http://downloadcontentcdn.opensuse.org/repositories/system:/systemd/Debian_Testing_images/ParticleOS-x86-64.efi

--- a/mkosi.images/netesp/mkosi.extra/efi/loader/entries/90-debian-testing-particleos-obs-current.conf
+++ b/mkosi.images/netesp/mkosi.extra/efi/loader/entries/90-debian-testing-particleos-obs-current.conf
@@ -1,0 +1,3 @@
+title Debian Testing ParticleOS Current from OBS (Network Boot)
+architecture x64
+uki-url http://downloadcontentcdn.opensuse.org/repositories/system:/systemd/debian_14_images/ParticleOS_x86-64.efi

--- a/mkosi.images/netesp/mkosi.extra/efi/loader/entries/90-fedora-41-particleos-obs-current.conf
+++ b/mkosi.images/netesp/mkosi.extra/efi/loader/entries/90-fedora-41-particleos-obs-current.conf
@@ -1,3 +1,0 @@
-title Fedora 41 ParticleOS Current from OBS (Network Boot)
-architecture x64
-uki-url http://downloadcontentcdn.opensuse.org/repositories/system:/systemd/Fedora_41_images/ParticleOS-x86-64.efi

--- a/mkosi.images/netesp/mkosi.extra/efi/loader/entries/90-fedora-42-particleos-obs-current.conf
+++ b/mkosi.images/netesp/mkosi.extra/efi/loader/entries/90-fedora-42-particleos-obs-current.conf
@@ -1,0 +1,3 @@
+title Fedora 42 ParticleOS Current from OBS (Network Boot)
+architecture x64
+uki-url http://downloadcontentcdn.opensuse.org/repositories/system:/systemd/fedora_42_images/ParticleOS_x86-64.efi

--- a/mkosi.images/netesp/mkosi.extra/efi/loader/entries/90-fedora-rawhide-particleos-obs-current.conf
+++ b/mkosi.images/netesp/mkosi.extra/efi/loader/entries/90-fedora-rawhide-particleos-obs-current.conf
@@ -1,3 +1,3 @@
 title Fedora Rawhide ParticleOS Current from OBS (Network Boot)
 architecture x64
-uki-url http://downloadcontentcdn.opensuse.org/repositories/system:/systemd/Fedora_Rawhide_images/ParticleOS-x86-64.efi
+uki-url http://downloadcontentcdn.opensuse.org/repositories/system:/systemd/fedora_44_images/ParticleOS_x86-64.efi


### PR DESCRIPTION
F41 was removed and F42 was added.
Deb13 was added. Rename testing to include 'testing' in the name