### PR TITLE
sshd: allow root logins via ssh

### DIFF
--- a/mkosi.extra/etc/ssh/sshd_config.d/50-rootok.conf
+++ b/mkosi.extra/etc/ssh/sshd_config.d/50-rootok.conf
@@ -1,0 +1,1 @@
+PermitRootLogin yes


### PR DESCRIPTION
The root user is often the only user present on the system, let's trust OpenSSH to authenticate it properly, and open this up by default.

This mimics a similar patch in systemd.