### PR TITLE
desktop: install qemu-guest-agent

### DIFF
--- a/mkosi.profiles/desktop/mkosi.conf
+++ b/mkosi.profiles/desktop/mkosi.conf
@@ -9,6 +9,7 @@ Packages=
         pgpdump
         pipewire
         pipewire-alsa
+        qemu-guest-agent
         wireless-regdb
         xdg-desktop-portal
 


### PR DESCRIPTION
Make clipboard and other niceties work out of the box. Won't run on hardware anyway as it's typically tied to virtio udev rules.