### PR TITLE
Add obs-sysupdate profile for sysupdate files pointing to OBS

### DIFF
--- a/mkosi.profiles/obs-sysupdate/mkosi.conf.d/debian-testing/mkosi.conf
+++ b/mkosi.profiles/obs-sysupdate/mkosi.conf.d/debian-testing/mkosi.conf
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=debian
+Release=|testing
+Release=|forky

--- a/mkosi.profiles/obs-sysupdate/mkosi.conf.d/debian-testing/mkosi.extra/usr/lib/sysupdate.d/20-particleos-kernel.transfer
+++ b/mkosi.profiles/obs-sysupdate/mkosi.conf.d/debian-testing/mkosi.extra/usr/lib/sysupdate.d/20-particleos-kernel.transfer
@@ -1,0 +1,19 @@
+[Transfer]
+ProtectVersion=%A
+
+[Source]
+Type=url-file
+Path=https://download.opensuse.org/repositories/system:/systemd/debian_testing_images/
+MatchPattern=ParticleOS_@v_%a.efi
+
+[Target]
+Type=regular-file
+Path=/EFI/Linux
+PathRelativeTo=boot
+MatchPattern=ParticleOS_@v_%a+@l-@d.efi \
+  ParticleOS_@v_%a+@l.efi \
+  ParticleOS_@v_%a.efi
+Mode=0644
+TriesLeft=3
+TriesDone=0
+InstancesMax=2

--- a/mkosi.profiles/obs-sysupdate/mkosi.conf.d/debian-testing/mkosi.extra/usr/lib/sysupdate.d/20-particleos-usr.transfer
+++ b/mkosi.profiles/obs-sysupdate/mkosi.conf.d/debian-testing/mkosi.extra/usr/lib/sysupdate.d/20-particleos-usr.transfer
@@ -1,0 +1,15 @@
+[Transfer]
+ProtectVersion=%A
+
+[Source]
+Type=url-file
+Path=https://download.opensuse.org/repositories/system:/systemd/debian_testing_images/
+MatchPattern=ParticleOS_@v_%a.usr-%a.@u.raw.zst
+
+[Target]
+Type=partition
+Path=auto
+MatchPattern=ParticleOS_@v
+MatchPartitionType=usr
+PartitionFlags=0
+ReadOnly=1

--- a/mkosi.profiles/obs-sysupdate/mkosi.conf.d/debian-testing/mkosi.extra/usr/lib/sysupdate.d/20-particleos-verity-sig.transfer
+++ b/mkosi.profiles/obs-sysupdate/mkosi.conf.d/debian-testing/mkosi.extra/usr/lib/sysupdate.d/20-particleos-verity-sig.transfer
@@ -1,0 +1,15 @@
+[Transfer]
+ProtectVersion=%A
+
+[Source]
+Type=url-file
+Path=https://download.opensuse.org/repositories/system:/systemd/debian_testing_images/
+MatchPattern=ParticleOS_@v_%a.usr-%a-verity-sig.@u.raw.zst
+
+[Target]
+Type=partition
+Path=auto
+MatchPattern=ParticleOS_@v_verity_sig
+MatchPartitionType=usr-verity-sig
+PartitionFlags=0
+ReadOnly=1

--- a/mkosi.profiles/obs-sysupdate/mkosi.conf.d/debian-testing/mkosi.extra/usr/lib/sysupdate.d/20-particleos-verity.transfer
+++ b/mkosi.profiles/obs-sysupdate/mkosi.conf.d/debian-testing/mkosi.extra/usr/lib/sysupdate.d/20-particleos-verity.transfer
@@ -1,0 +1,15 @@
+[Transfer]
+ProtectVersion=%A
+
+[Source]
+Type=url-file
+Path=https://download.opensuse.org/repositories/system:/systemd/debian_testing_images/
+MatchPattern=ParticleOS_@v_%a.usr-%a-verity.@u.raw.zst
+
+[Target]
+Type=partition
+Path=auto
+MatchPattern=ParticleOS_@v_verity
+MatchPartitionType=usr-verity
+PartitionFlags=0
+ReadOnly=1

--- a/mkosi.profiles/obs-sysupdate/mkosi.extra/usr/lib/sysupdate.d/20-particleos-kernel.transfer
+++ b/mkosi.profiles/obs-sysupdate/mkosi.extra/usr/lib/sysupdate.d/20-particleos-kernel.transfer
@@ -1,0 +1,19 @@
+[Transfer]
+ProtectVersion=%A
+
+[Source]
+Type=url-file
+Path=https://download.opensuse.org/repositories/system:/systemd/%o_%w_images/
+MatchPattern=ParticleOS_@v_%a.efi
+
+[Target]
+Type=regular-file
+Path=/EFI/Linux
+PathRelativeTo=boot
+MatchPattern=ParticleOS_@v_%a+@l-@d.efi \
+  ParticleOS_@v_%a+@l.efi \
+  ParticleOS_@v_%a.efi
+Mode=0644
+TriesLeft=3
+TriesDone=0
+InstancesMax=2

--- a/mkosi.profiles/obs-sysupdate/mkosi.extra/usr/lib/sysupdate.d/20-particleos-usr.transfer
+++ b/mkosi.profiles/obs-sysupdate/mkosi.extra/usr/lib/sysupdate.d/20-particleos-usr.transfer
@@ -1,0 +1,15 @@
+[Transfer]
+ProtectVersion=%A
+
+[Source]
+Type=url-file
+Path=https://download.opensuse.org/repositories/system:/systemd/%o_%w_images/
+MatchPattern=ParticleOS_@v_%a.usr-%a.@u.raw.zst
+
+[Target]
+Type=partition
+Path=auto
+MatchPattern=ParticleOS_@v
+MatchPartitionType=usr
+PartitionFlags=0
+ReadOnly=1

--- a/mkosi.profiles/obs-sysupdate/mkosi.extra/usr/lib/sysupdate.d/20-particleos-verity-sig.transfer
+++ b/mkosi.profiles/obs-sysupdate/mkosi.extra/usr/lib/sysupdate.d/20-particleos-verity-sig.transfer
@@ -1,0 +1,15 @@
+[Transfer]
+ProtectVersion=%A
+
+[Source]
+Type=url-file
+Path=https://download.opensuse.org/repositories/system:/systemd/%o_%w_images/
+MatchPattern=ParticleOS_@v_%a.usr-%a-verity-sig.@u.raw.zst
+
+[Target]
+Type=partition
+Path=auto
+MatchPattern=ParticleOS_@v_verity_sig
+MatchPartitionType=usr-verity-sig
+PartitionFlags=0
+ReadOnly=1

--- a/mkosi.profiles/obs-sysupdate/mkosi.extra/usr/lib/sysupdate.d/20-particleos-verity.transfer
+++ b/mkosi.profiles/obs-sysupdate/mkosi.extra/usr/lib/sysupdate.d/20-particleos-verity.transfer
@@ -1,0 +1,15 @@
+[Transfer]
+ProtectVersion=%A
+
+[Source]
+Type=url-file
+Path=https://download.opensuse.org/repositories/system:/systemd/%o_%w_images/
+MatchPattern=ParticleOS_@v_%a.usr-%a-verity.@u.raw.zst
+
+[Target]
+Type=partition
+Path=auto
+MatchPattern=ParticleOS_@v_verity
+MatchPartitionType=usr-verity
+PartitionFlags=0
+ReadOnly=1


### PR DESCRIPTION
Add a profile that adds sysupdate.d configs pointing to OBS. Unfortunately os-release is broken on debian testing and does not have a VERSION_ID or anything else that can be used, so it needs a special file.
The rest can use specifiers.