### PR TITLE
Arch: don't install duplicate microcode to ESP

### DIFF
--- a/mkosi.conf.d/arch/mkosi.conf
+++ b/mkosi.conf.d/arch/mkosi.conf
@@ -39,5 +39,8 @@ Packages=
         xz
         zram-generator
 
+RemoveFiles=
+        /boot/*-ucode.img
+
 VolatilePackages=
         systemd-ukify


### PR DESCRIPTION
_vendor_-ucode.img is not used by mkosi and is therefore needlessly copied over to the ESP

See https://wiki.archlinux.org/title/Microcode#Microcode_initramfs_packed_together_with_the_main_initramfs_in_one_file