### PR TITLE
Add support for openSUSE distribution

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -36,6 +36,7 @@ Packages=
         attr
         bash-completion
         btrfs-progs
+        ca-certificates
         coreutils
         cpio
         curl

--- a/mkosi.conf.d/opensuse/mkosi.conf
+++ b/mkosi.conf.d/opensuse/mkosi.conf
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=opensuse
+
+[Distribution]
+Release=tumbleweed
+
+[Build]
+# By default erofs is blacklisted in openSUSE and UKIs use erofs for the usrfs
+Environment=
+        SYSTEMD_REPART_OVERRIDE_FSTYPE_USR=squashfs
+
+[Content]
+# Some pcrlock files from the experimental package are still needed in the
+# initrd to unseal TPM as:
+# - /usr/lib/systemd/system/systemd-pcrlock-file-system.service
+# - /usr/lib/systemd/system/systemd-pcrlock-firmware-code.service
+# - /usr/lib/systemd/system/systemd-pcrlock-firmware-config.service
+InitrdPackages=
+        systemd-experimental
+
+Packages=
+        bpftool
+        cryptsetup
+        distribution-gpg-keys
+        git-core
+        iproute2
+        iputils
+        kernel-default
+        libcap-ng-utils
+        libfido2-1
+        # Needed for TPM2 tools
+        libtss2-tcti-device0
+        man
+        openssh
+        openssh-clients
+        openssh-server
+        patterns-base-minimal_base
+        pam
+        pam_pwquality
+        pcsc-lite
+        pcsc-ccid
+        perf
+        polkit
+        procps
+        python3
+        rpm
+        sbsigntools
+        shadow
+        systemd-boot
+        systemd-container
+        systemd-experimental
+        systemd-homed
+        systemd-networkd
+        systemd-resolved
+        systemd-ukify
+        tpm2.0-tools
+        tpm2-0-tss
+        veritysetup
+        vim-small
+        wget2
+        xz
+        zram-generator
+        zypper
+
+VolatilePackages=
+        systemd-boot
+        systemd-container
+        systemd-homed
+        systemd-networkd
+        systemd-resolved
+        systemd-ukify

--- a/mkosi.profiles/obs/mkosi.conf.d/opensuse-tools.conf
+++ b/mkosi.profiles/obs/mkosi.conf.d/opensuse-tools.conf
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+ToolsTreeDistribution=opensuse
+ToolsTreeRelease=tumbleweed
+
+[Build]
+ToolsTreeSandboxTrees=systemd.gpg:/usr/share/pki/rpm-gpg/systemd.gpg
+                      opensuse.repo:/etc/zypp/repos.d/systemd.repo

--- a/mkosi.profiles/obs/mkosi.conf.d/opensuse.conf
+++ b/mkosi.profiles/obs/mkosi.conf.d/opensuse.conf
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=opensuse
+Release=tumbleweed
+
+[Build]
+SandboxTrees=systemd.gpg:/usr/share/pki/rpm-gpg/systemd.gpg
+             opensuse.repo:/etc/zypp/repos.d/systemd.repo

--- a/mkosi.profiles/obs/opensuse.repo
+++ b/mkosi.profiles/obs/opensuse.repo
@@ -1,0 +1,7 @@
+[system_systemd]
+name=system:systemd Project (openSUSE_Tumbleweed)
+type=rpm-md
+baseurl=https://download.opensuse.org/repositories/system:/systemd/openSUSE_Tumbleweed
+gpgcheck=1
+gpgkey=file:///usr/share/pki/rpm-gpg/systemd.gpg
+enabled=1


### PR DESCRIPTION
* Add new sub-image "initrd" to control the initrd content.
  * Un-blacklist the erofs for openSUSE image.
* openSUSE obs profile
* configurations for basic openSUSE Tumbleweed image.