### PR TITLE
Arch: Add/fix 'checkupdates' utility from 'pacman-contrib'.

### DIFF
--- a/mkosi.conf.d/arch/mkosi.conf
+++ b/mkosi.conf.d/arch/mkosi.conf
@@ -12,6 +12,7 @@ Packages=
         cryptsetup
         dbus-broker-units
         expac
+        fakeroot
         git
         iproute2
         iputils
@@ -21,6 +22,7 @@ Packages=
         man-pages
         openssh
         pacman
+        pacman-contrib
         pcsclite
         perf
         polkit

--- a/mkosi.conf.d/arch/mkosi.extra/etc/pacman.conf
+++ b/mkosi.conf.d/arch/mkosi.extra/etc/pacman.conf
@@ -2,3 +2,17 @@
 
 [options]
 DBPath = /usr/lib/pacman
+Architecture = auto
+Color
+HoldPkg = pacman glibc
+CheckSpace
+ParallelDownloads = 5
+DownloadUser = alpm
+SigLevel = Required DatabaseOptional
+LocalFileSigLevel = Optional
+
+[core]
+Server = https://fastly.mirror.pkgbuild.com/$repo/os/$arch
+
+[extra]
+Server = https://fastly.mirror.pkgbuild.com/$repo/os/$arch


### PR DESCRIPTION
This allows checking for updates safely with `$ checkupdates ` in order to decide on whether it's time to build a new image..