### PR TITLE
Disable zswap on Arch, since zram is enabled.

### DIFF
--- a/mkosi.conf.d/arch/mkosi.conf
+++ b/mkosi.conf.d/arch/mkosi.conf
@@ -44,3 +44,7 @@ RemoveFiles=
 
 VolatilePackages=
         systemd-ukify
+
+# Arch enables zswap by default, but particleos already has zram
+KernelCommandLine=
+	zswap.enabled=0


### PR DESCRIPTION
Arch has zswap enabled by default, whereas Fedora/Debian don't.  So currently, ParticleOS Arch images have both zswap and zram enabled concurrently which the [Arch wiki](https://wiki.archlinux.org/title/Zram#Usage_as_swap) says we shouldn't do.

So we should either disable zswap as per this PR, or **alternatively remove zram-generator** from default packages on the Arch profile (which might be simpler and closer to distro default ?)

See also https://github.com/systemd/particleos/issues/41#issuecomment-3388753694