### PR TITLE
Arch, Fedora, Debian: use tuned

### DIFF
--- a/mkosi.extra/usr/lib/repart.d/30-swap.conf
+++ b/mkosi.extra/usr/lib/repart.d/30-swap.conf
@@ -3,8 +3,8 @@
 [Partition]
 Type=swap
 Format=swap
-SizeMinBytes=8G
-SizeMaxBytes=8G
+SizeMinBytes=4G
+SizeMaxBytes=4G
 Encrypt=tpm2
 FactoryReset=yes
 Label=%M-swap

--- a/mkosi.extra/usr/lib/repart.d/30-swap.conf
+++ b/mkosi.extra/usr/lib/repart.d/30-swap.conf
@@ -3,8 +3,8 @@
 [Partition]
 Type=swap
 Format=swap
-SizeMinBytes=4G
-SizeMaxBytes=4G
+SizeMinBytes=8G
+SizeMaxBytes=8G
 Encrypt=tpm2
 FactoryReset=yes
 Label=%M-swap

--- a/mkosi.extra/usr/lib/systemd/system-preset/10-particleos.preset
+++ b/mkosi.extra/usr/lib/systemd/system-preset/10-particleos.preset
@@ -19,8 +19,8 @@ enable systemd-homed-firstboot.service
 # Disable avahi in favor of resolved
 disable avahi.*
 
+# Enable support for smart card readers
 enable pcscd.service
-enable power-profiles-daemon.service
 
 # Our own service to run systemctl preset --global.
 enable preset-global.service

--- a/mkosi.extra/usr/lib/systemd/system-preset/10-particleos.preset
+++ b/mkosi.extra/usr/lib/systemd/system-preset/10-particleos.preset
@@ -22,6 +22,10 @@ disable avahi.*
 # Enable support for smart card readers
 enable pcscd.service
 
+# Enable tuned for power management
+enable tuned.service
+enable tuned-ppd.service
+
 # Our own service to run systemctl preset --global.
 enable preset-global.service
 

--- a/mkosi.profiles/desktop/mkosi.conf
+++ b/mkosi.profiles/desktop/mkosi.conf
@@ -10,6 +10,7 @@ Packages=
         pipewire
         pipewire-alsa
         qemu-guest-agent
+        tuned-ppd
         wireless-regdb
         xdg-desktop-portal
 

--- a/mkosi.profiles/desktop/mkosi.conf.d/arch/mkosi.conf
+++ b/mkosi.profiles/desktop/mkosi.conf.d/arch/mkosi.conf
@@ -14,7 +14,6 @@ Packages=
         networkmanager
         noto-fonts
         pipewire-pulse
-        power-profiles-daemon
         sof-firmware
         vulkan-intel
         vulkan-nouveau

--- a/mkosi.profiles/desktop/mkosi.conf.d/debian/mkosi.conf
+++ b/mkosi.profiles/desktop/mkosi.conf.d/debian/mkosi.conf
@@ -25,7 +25,6 @@ Packages=
         pipewire-pulse
         plymouth-themes
         steam-devices
-        tuned-ppd
         va-driver-all
         wpasupplicant
 

--- a/mkosi.profiles/desktop/mkosi.conf.d/fedora/mkosi.conf
+++ b/mkosi.profiles/desktop/mkosi.conf.d/fedora/mkosi.conf
@@ -25,5 +25,4 @@ Packages=
         nvidia-gpu-firmware
         pipewire-pulseaudio
         steam-devices
-        tuned-ppd
         wpa_supplicant


### PR DESCRIPTION
Fedora switched to this on Fedora 41: https://fedoraproject.org/wiki/Changes/TunedAsTheDefaultPowerProfileManagementDaemon

I believe it works for all support distros, and I don't know if it should be enabled by default, I thought the DE takes care of that?

This PR was original only for Arch Linux, but I think all three supported distros support this including DE's.