### PR TITLE
Readme:  Mention `ToolsTreeProfiles=package-manager` when building for another distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,19 @@ desktop system, you'll want the `desktop` and one of `gnome`, `kde`, or
 `sway` profiles.
 
 ```conf
+[Config]
+Profiles=desktop,kde
+```
+
+When building for a different distribution than the one you are currently running,
+you must also specify the distribution and include the required tools:
+
+```conf
 [Distribution]
 Distribution=arch
 
-[Config]
-Profiles=desktop,kde
+[Build]
+ToolsTreeProfiles=package-manager
 ```
 
 It is also strongly recommended to write a hashed root password prefixed with


### PR DESCRIPTION
~Use `--defer-partitions-factory-reset yes`
Requires systemd 259~

Removed parts which are obsolete now when using sysinstall