### PR TITLE
debian: add back Splash=

### DIFF
--- a/mkosi.profiles/desktop/mkosi.conf.d/debian/mkosi.conf.d/splash.conf
+++ b/mkosi.profiles/desktop/mkosi.conf.d/debian/mkosi.conf.d/splash.conf
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[TriggerMatch]
+Distribution=debian
+Release=!bullseye
+Release=!bookworm
+Release=!trixie
+
+[Content]
+Splash=/usr/share/pixmaps/debian-logo.bmp


### PR DESCRIPTION
A bmp logo is now shipped in debconf in forky/unstable