### PR TITLE
Add a profile to enable audit, retaining disabled by default behavior.

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -24,7 +24,6 @@ KernelCommandLine=
         root=dissect
         mount.usr=dissect
         rw
-        audit=0
         systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:root=encrypted+absent:swap=encrypted+unused+absent:home=unprotected+absent:=ignore
         systemd.image_filter=usr=ParticleOS_*:usr-verity=ParticleOS_*:usr-verity-sig=ParticleOS_*:root=ParticleOS-*:swap=ParticleOS-*:home=ParticleOS-*
         ipe.enforce=0

--- a/mkosi.conf.d/audit.conf
+++ b/mkosi.conf.d/audit.conf
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Profiles=!audit
+
+[Runtime]
+KernelCommandLineExtra=audit=0

--- a/mkosi.extra/usr/lib/tmpfiles.d/etc.conf
+++ b/mkosi.extra/usr/lib/tmpfiles.d/etc.conf
@@ -74,3 +74,5 @@ L? /etc/manpath.config
 L? /etc/wpa_supplicant/wpa_supplicant.conf
 # Make sure flatpak's XDG_DATA_DIR integration works
 L? /etc/profile.d/flatpak.sh
+# Required for audit profile
+L? /etc/audit

--- a/mkosi.profiles/audit/mkosi.conf.d/fedora/mkosi.conf
+++ b/mkosi.profiles/audit/mkosi.conf.d/fedora/mkosi.conf
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=fedora
+
+[Content]
+Packages=
+        audit-rules
+        audit

--- a/mkosi.uki-profiles/10-live.conf
+++ b/mkosi.uki-profiles/10-live.conf
@@ -17,7 +17,6 @@ Cmdline=
         systemd.journald.forward_to_console=1
         systemd.journald.max_level_console=warning
         rw
-        audit=0
         systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:=ignore
         systemd.image_filter=usr=ParticleOS_*:usr-verity=ParticleOS_*:usr-verity-sig=ParticleOS_*
         ipe.enforce=0

--- a/mkosi.uki-profiles/20-ipe.conf
+++ b/mkosi.uki-profiles/20-ipe.conf
@@ -10,7 +10,6 @@ Cmdline=
         mount.usr=dissect
         systemd.verity_usr_options=root-hash-signature=auto
         rw
-        audit=0
         systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:root=encrypted+absent:swap=encrypted+unused+absent:home=unprotected+absent:=ignore
         systemd.image_filter=usr=ParticleOS_*:usr-verity=ParticleOS_*:usr-verity-sig=ParticleOS_*:root=ParticleOS-*:swap=ParticleOS-*:home=ParticleOS-*
         ipe.enforce=1

--- a/mkosi.uki-profiles/80-storagetm.conf
+++ b/mkosi.uki-profiles/80-storagetm.conf
@@ -9,7 +9,6 @@ Cmdline=
         rd.systemd.unit=storage-target-mode.target
         ip=any
         ro
-        audit=0
         systemd.image_policy=-
         root=off
         ipe.enforce=0

--- a/mkosi.uki-profiles/90-factory-reset.conf
+++ b/mkosi.uki-profiles/90-factory-reset.conf
@@ -10,7 +10,6 @@ Cmdline=
         mount.usr=dissect
         systemd.factory_reset=1
         rw
-        audit=0
         systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:root=encrypted+absent:swap=encrypted+unused+absent:home=unprotected+absent:=ignore
         systemd.image_filter=usr=ParticleOS_*:usr-verity=ParticleOS_*:usr-verity-sig=ParticleOS_*:root=ParticleOS-*:swap=ParticleOS-*:home=ParticleOS-*
         ipe.enforce=0

--- a/mkosi.uki-profiles/91-factory-reset-with-tpm-clear.conf
+++ b/mkosi.uki-profiles/91-factory-reset-with-tpm-clear.conf
@@ -8,7 +8,6 @@ Profile=
 Cmdline=
         rd.systemd.unit=factory-reset.target
         ro
-        audit=0
         systemd.image_policy=-
         root=off
         ipe.enforce=0

--- a/mkosi.uki-profiles/95-emergency.conf
+++ b/mkosi.uki-profiles/95-emergency.conf
@@ -10,7 +10,6 @@ Cmdline=
         mount.usr=dissect
         systemd.unit=emergency.target
         rw
-        audit=0
         systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:root=encrypted+absent:swap=encrypted+unused+absent:home=unprotected+absent:=ignore
         systemd.image_filter=usr=ParticleOS_*:usr-verity=ParticleOS_*:usr-verity-sig=ParticleOS_*:root=ParticleOS-*:swap=ParticleOS-*:home=ParticleOS-*
         ipe.enforce=0

--- a/mkosi.uki-profiles/99-debug.conf
+++ b/mkosi.uki-profiles/99-debug.conf
@@ -12,7 +12,6 @@ Cmdline=
         systemd.log_level=debug
         systemd.journald.forward_to_console=1
         rw
-        audit=0
         systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:root=encrypted+absent:swap=encrypted+unused+absent:home=unprotected+absent:=ignore
         systemd.image_filter=usr=ParticleOS_*:usr-verity=ParticleOS_*:usr-verity-sig=ParticleOS_*:root=ParticleOS-*:swap=ParticleOS-*:home=ParticleOS-*
         ipe.enforce=0


### PR DESCRIPTION
Include initial support for Fedora.

Example addition to mkosi.local.conf:

  [Config]
  Profiles=audit

This will be needed to debug & effectively utilize SELinux (when that is enabled).
