### PR TITLE
Readme: Revise LUKS recovery key instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ the installation.
 
 systemd doesn't support adding a recovery key to a partition enrolled with a token
 only (tpm/fido2). It is possible to use cryptenroll to add a recovery password
-to the root partition: `cryptsetup luksAddKey --token-type systemd-tpm2 /dev/<id>`
+to the root partition: `systemd-cryptenroll --unlock-tpm2-device auto --recovery-key /dev/disk/by-designator/root-luks`
 
 ## Firmwares
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ systemd-sysinstall(8) man page for details.
 
 systemd doesn't support adding a recovery key to a partition enrolled with a token
 only (tpm/fido2). It is possible to use cryptenroll to add a recovery password
-to the root partition: `cryptsetup luksAddKey --token-type systemd-tpm2 /dev/<id>`
+to the root partition: `systemd-cryptenroll --unlock-tpm2-device auto --recovery-key /dev/disk/by-designator/root-luks`
 
 ## Firmwares
 


### PR DESCRIPTION
Updated instructions for adding a recovery key to a LUKS partition using `systemd-cryptenroll` and  `/dev/disk/by-designator/root-luks`

No need to use `/dev/disk/..`