### PR TITLE
Enable avahi for 'desktop' profile, required for network printer lookups

### DIFF
--- a/mkosi.profiles/desktop/mkosi.conf.d/arch/mkosi.conf
+++ b/mkosi.profiles/desktop/mkosi.conf.d/arch/mkosi.conf
@@ -13,6 +13,7 @@ Packages=
         modemmanager
         networkmanager
         noto-fonts
+        nss-mdns
         pipewire-pulse
         power-profiles-daemon
         sof-firmware

--- a/mkosi.profiles/desktop/mkosi.conf.d/debian/mkosi.conf
+++ b/mkosi.profiles/desktop/mkosi.conf.d/debian/mkosi.conf
@@ -17,6 +17,7 @@ Packages=
         gstreamer1.0-libav
         gstreamer1.0-plugins-ugly
         kbd
+        libnss-mdns
         libsecret-tools
         libyubikey-udev
         locales-all

--- a/mkosi.profiles/desktop/mkosi.conf.d/fedora/mkosi.conf
+++ b/mkosi.profiles/desktop/mkosi.conf.d/fedora/mkosi.conf
@@ -23,6 +23,7 @@ Packages=
         ModemManager
         NetworkManager
         NetworkManager-wifi
+        nss-mdns
         nvidia-gpu-firmware
         pipewire-pulseaudio
         steam-devices

--- a/mkosi.profiles/desktop/mkosi.extra/usr/lib/systemd/resolved.conf.d/10-mdns.conf
+++ b/mkosi.profiles/desktop/mkosi.extra/usr/lib/systemd/resolved.conf.d/10-mdns.conf
@@ -1,0 +1,2 @@
+[Resolve]
+MulticastDNS=0

--- a/mkosi.profiles/desktop/mkosi.extra/usr/lib/systemd/system-preset/10-avahi.preset
+++ b/mkosi.profiles/desktop/mkosi.extra/usr/lib/systemd/system-preset/10-avahi.preset
@@ -1,0 +1,2 @@
+# Enable Avahi for Cups
+enable avahi-daemon.service

--- a/mkosi.profiles/desktop/mkosi.extra/usr/lib/tmpfiles.d/particleos-avahi.conf
+++ b/mkosi.profiles/desktop/mkosi.extra/usr/lib/tmpfiles.d/particleos-avahi.conf
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# Cups needs Avahi for DNS-SD. See https://github.com/OpenPrinting/libcups/issues/81
+L /etc/avahi/


### PR DESCRIPTION
Avahi is needed for cups to discover/add network printer via DNS-SD (See https://github.com/OpenPrinting/libcups/issues/81).

So this:
* enables avahi, with the nss-mdns plugin
* disables systemd-resolved's multicast DNS resolver/responder to avoid conflicting with avahi
* symlinks the configuration folder