### PR TITLE
Arch: Use distro default of zswap instead of zram.

### DIFF
--- a/mkosi.conf.d/arch/mkosi.conf
+++ b/mkosi.conf.d/arch/mkosi.conf
@@ -37,7 +37,6 @@ Packages=
         vim-minimal
         wget
         xz
-        zram-generator
 
 RemoveFiles=
         /boot/*-ucode.img

--- a/mkosi.conf.d/arch/mkosi.extra/usr/lib/systemd/zram-generator.conf
+++ b/mkosi.conf.d/arch/mkosi.extra/usr/lib/systemd/zram-generator.conf
@@ -1,2 +1,0 @@
-[zram0]
-#zram-size = min(ram / 2, 4096)


### PR DESCRIPTION
Prefer Arch distro default of zswap vs setting up zram.

Arch already uses zswap by default, and both zswap and zram shouldn't be used simultaneously.

See https://github.com/systemd/particleos/pull/130 for some discussion and https://chrisdown.name/2026/03/24/zswap-vs-zram-when-to-use-what.html for some context.