### PR TITLE
particleos: add support for sysinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,24 +181,36 @@ as well.
 
 ## Installation
 
-Before installing ParticleOS, make sure that Secure Boot is in setup mode on the
-target system. The Secure Boot mode can be configured in the UEFI firmware
-interface of the target system. If there's an existing Linux installation on the
-target system already, run `systemctl reboot --firmware-setup` to reboot into
-the UEFI firmware interface. At the same time, make sure the UEFI firmware
-interface is password protected so an attacker cannot just disable Secure Boot
+Before installing ParticleOS, make sure that Secure Boot is in *setup*
+*mode* on the target system. The Secure Boot mode can be configured in
+the UEFI firmware interface of the target system. If there's an
+existing Linux installation on the target system already, run
+`systemctl reboot --firmware-setup` to reboot into the UEFI firmware
+interface. At the same time, make sure the UEFI firmware interface is
+password protected so an attacker cannot just disable Secure Boot
 again.
 
-To install ParticleOS with a USB drive, first build the image on an existing
-Linux system as described above. Then, burn it to the USB drive with
-`mkosi burn /dev/<usb>`. Once burned to the USB drive, plug the USB drive into
-the system onto which you'd like to install ParticleOS and boot into the USB
-drive via the firmware. Then, boot into the "Installer" UKI profile. When you
-end up in the root shell, run
-`systemd-repart --dry-run=no --empty=force --defer-partitions=swap,root,home /dev/<drive>`
-to install ParticleOS to the system's drive. Finally, reboot into the target
-drive (not the USB) and the regular profile (not the installer one) to complete
-the installation.
+To install ParticleOS with a USB drive, first build the image on an
+existing Linux system as described above. Then, write it to the USB
+drive with `mkosi burn /dev/<usb>`. Once written to the USB drive, plug
+the USB drive into the system onto which you'd like to install
+ParticleOS and boot into the USB drive via the firmware menu. Then,
+boot into the "Installer" UKI profile, which runs
+`systemd-sysinstall`. It will prompt for the target drive and any
+other details required, then partition the disk, copy ParticleOS onto
+it, set up the ESP via `bootctl install` and finally install a kernel
+via `bootctl link`. Once it completes, reboot into the target drive
+(i.e not the USB drive) and the default profile (i.e. not the
+installer one) to complete the installation.
+
+If you prefer to drive the install manually, boot into the "Live
+System" UKI profile instead. When you end up in the root shell, run
+`systemd-sysinstall` to install ParticleOS to the system's drive,
+then reboot as above. If you invoke `systemd-sysinstall` without
+arguments it will interactively query you for configuration
+parameters, as necessary. You may alternatively configure the new
+installation with command line parameters of the tool, see the
+systemd-sysinstall(8) man page for details.
 
 ## LUKS recovery key
 

--- a/mkosi.conf.d/fedora/mkosi.conf
+++ b/mkosi.conf.d/fedora/mkosi.conf
@@ -7,6 +7,9 @@ Distribution=fedora
 Release=rawhide
 
 [Content]
+InitrdPackages=
+        libfdisk
+
 Packages=
         bash-color-prompt
         bpftool

--- a/mkosi.extra/usr/lib/repart.d/00-esp.conf
+++ b/mkosi.extra/usr/lib/repart.d/00-esp.conf
@@ -3,6 +3,5 @@
 [Partition]
 Type=esp
 Format=vfat
-CopyFiles=/boot:/
 SizeMinBytes=1G
 SizeMaxBytes=1G

--- a/mkosi.uki-profiles/20-install.conf
+++ b/mkosi.uki-profiles/20-install.conf
@@ -2,18 +2,16 @@
 
 [UKIProfile]
 Profile=
-        ID=live
-        TITLE=Live System
+        ID=install
+        TITLE=Installer
 
 Cmdline=
         root=tmpfs
         mount.usr=dissect
         rd.systemd.mask=systemd-repart.service
         systemd.mask=systemd-repart.service
+        systemd.unit=system-install.target
         systemd.set-credential=passwd.plaintext-password.root:particleos
-        systemd.set-credential=agetty.autologin:root
-        systemd.set-credential=login.noauth:yes
-        SYSTEMD_SULOGIN_FORCE=1
         rw
         audit=0
         systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:=ignore


### PR DESCRIPTION
This adds a new UKI profile for booting in installer mode, using the recently merged sysinstall feature of systemd:

https://github.com/systemd/systemd/pull/41877

This also changes the live mode (which is very similar) to not disable firstboot, but instead uses credentials to tweak the prompts. This is beneficial, since we want firstboot to run always, not because of the interactivity features, but simply because it processes a bunch of firstboot.* credentials we want.

It also gets rid of the changes made to console logging. That's useful for the debug boot mode, but is inappropriate for the installer and live profiles which should just be "clean"

This makes usr/lib/repart.sysinstall.d/ almost identical to the regular /usr/lib/repart.d/ with one exception: the CopyFiles= line is dropped now, because we don't need it in the installer case (because sysinstall utilizes bootctl link + bootctl install to initialize the ESP properly). Eventually we probably should drop CopyFiles= entirely, but after discussing with Daan this day is not today yet.