### PR TITLE
sway: Add profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ You will need to install the current main branch of mkosi to build current
 ParticleOS images.
 
 First, configure the variant you'd like to build in `mkosi.local.conf`. For a
-desktop system, you'll want the `desktop` profile and either the `gnome` or the
-`kde` profile.
+desktop system, you'll want the `desktop` and one of `gnome`, `kde`, or
+`sway` profiles.
 
 ```conf
 [Distribution]

--- a/mkosi.profiles/sway/mkosi.conf
+++ b/mkosi.profiles/sway/mkosi.conf
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# Requires desktop profile
+
+[Content]
+Packages=
+        blueman
+        dunst
+        foot
+        grim
+        gvfs
+        imv
+        kanshi
+        lxqt-policykit
+        network-manager-applet
+        pavucontrol
+        pinentry-gnome3
+        playerctl
+        pulseaudio-utils
+        rofi
+        rofimoji
+        sddm
+        slurp
+        sway
+        swaybg
+        swayidle
+        swaylock
+        system-config-printer
+        waybar
+        wev
+        wl-clipboard
+        wlr-randr
+        wlsunset
+        xarchiver
+        xdg-desktop-portal-gtk
+        xdg-desktop-portal-wlr

--- a/mkosi.profiles/sway/mkosi.conf.d/debian/mkosi.conf
+++ b/mkosi.profiles/sway/mkosi.conf.d/debian/mkosi.conf
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=debian
+
+[Content]
+Packages=
+        fonts-font-awesome
+        fprintd
+        gvfs-backends
+        libpam-gnome-keyring
+        thunar
+        thunar-archive-plugin
+        xwayland

--- a/mkosi.profiles/sway/mkosi.conf.d/fedora/mkosi.conf
+++ b/mkosi.profiles/sway/mkosi.conf.d/fedora/mkosi.conf
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=fedora
+
+[Content]
+Packages=
+        fontawesome-6-brands-fonts
+        fontawesome-6-free-fonts
+        fprintd-pam
+        gnome-keyring-pam
+        gvfs-smb
+        plymouth-system-theme
+        polkit
+        sddm-wayland-sway
+        sway-config-fedora
+        Thunar
+        thunar-archive-plugin
+        tuned-switcher
+        xorg-x11-server-Xwayland

--- a/mkosi.profiles/sway/mkosi.extra/usr/lib/tmpfiles.d/particleos-sway.conf
+++ b/mkosi.profiles/sway/mkosi.extra/usr/lib/tmpfiles.d/particleos-sway.conf
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# Enable sway and sddm configuration
+L /etc/sddm.conf - - - -
+L /etc/sddm.conf.d - - - -
+L /etc/sddm - - - -
+L /etc/sway - - - -
+L /etc/swaylock - - - -


### PR DESCRIPTION
Start with the packages. Keep the ones which exist in Debian and Fedora in the common mkosi.conf, and add some distro specifics.
    
Package list based on Fedora Sway desktop:
https://forge.fedoraproject.org/atomic-desktops/config/src/branch/main/packages/sway-atomic.yaml

----

This is a stock boot, which looks happy enough:

<img width="1289" height="826" alt="out" src="https://github.com/user-attachments/assets/36ca17e3-3266-425b-b240-40a5827933f8" />

Draft for now, there are still a few things I want to do:

 - [x] Test/fix Debian build
 - [x] Test this on actual hardware