### PR TITLE
Give root privileges to particleos user on Debian based OSes

### DIFF
--- a/mkosi.credentials/home.create.particleos
+++ b/mkosi.credentials/home.create.particleos
@@ -5,6 +5,7 @@
     "disposition": "regular",
     "enforcePasswordPolicy": false,
     "memberOf": [
+        "sudo",
         "wheel",
         "systemd-journal"
     ],


### PR DESCRIPTION
The `wheel` group is spelled `sudo` on these. Nonexisting groups are ignored, so this is a no-op for Fedora.

---

I tested this both with a Fedora rawhide build (no change, user is in `wheel` and no `sudo` group) and Debian testing (`particleos` user can now do `run0` with its password) 