### PR TITLE
fedora: Move emoji font to desktop, add math font

### DIFF
--- a/mkosi.profiles/desktop/mkosi.conf.d/fedora/mkosi.conf
+++ b/mkosi.profiles/desktop/mkosi.conf.d/fedora/mkosi.conf
@@ -9,6 +9,8 @@ Packages=
         adobe-source-code-pro-fonts
         alsa-sof-firmware
         amd-gpu-firmware
+        default-fonts-core-emoji
+        default-fonts-core-math
         fedora-logos
         glibc-all-langpacks
         glx-utils

--- a/mkosi.profiles/gnome/mkosi.conf.d/fedora/mkosi.conf
+++ b/mkosi.profiles/gnome/mkosi.conf.d/fedora/mkosi.conf
@@ -6,7 +6,6 @@ Distribution=fedora
 [Content]
 Packages=
         adwaita-fonts-all
-        default-fonts-core-emoji
         gdm
         pinentry-gnome3
         rsms-inter-fonts


### PR DESCRIPTION
Because ∑ 🙂 = 😁!
    
These apply to other desktop environments as well, like the upcoming sway.
