### PR TITLE
sway: Add missing sway-systemd on Fedora

### DIFF
--- a/mkosi.profiles/sway/mkosi.conf.d/fedora/mkosi.conf
+++ b/mkosi.profiles/sway/mkosi.conf.d/fedora/mkosi.conf
@@ -14,6 +14,7 @@ Packages=
         polkit
         sddm-wayland-sway
         sway-config-fedora
+        sway-systemd
         Thunar
         thunar-archive-plugin
         tuned-switcher


### PR DESCRIPTION
This provides the necessary `sway-session.target` integration, unbreaking e.g. the notification daemon or gnome-keyring SSH agent.