### PR TITLE
Allow larger swap partition when possible.

### DIFF
--- a/mkosi.extra/usr/lib/repart.d/30-swap.conf
+++ b/mkosi.extra/usr/lib/repart.d/30-swap.conf
@@ -4,7 +4,8 @@
 Type=swap
 Format=swap
 SizeMinBytes=4G
-SizeMaxBytes=4G
+SizeMaxBytes=16G
+Weight=4000
 Encrypt=tpm2
 FactoryReset=yes
 Label=%M-swap


### PR DESCRIPTION
On my 1TB disk, the current `repart.d` configuration files only allow for a 4G swap partiition, and hibernation fails most of the time for lack of disk space.

This change allows for about 5% of the disk to be allocated to swap, up to 16G which should cover most cases. The full 16G should be allocated roughly for disks larger 300G.