### PR TITLE
Set max size for the root partition to be 40G

### DIFF
--- a/mkosi.extra/usr/lib/repart.d/40-root.conf
+++ b/mkosi.extra/usr/lib/repart.d/40-root.conf
@@ -4,6 +4,7 @@
 Type=root
 Format=btrfs
 SizeMinBytes=1G
+SizeMaxBytes=40G
 Weight=20000
 Subvolumes=/var
 MakeDirectories=/var/log/journal


### PR DESCRIPTION
I noticed that when installing on hardware with a 1TB disk it setup the root partition to be 300GB, which IMHO is quite large for a root partition (I am currently only using 15GB with several flatpaks, sysexts, etc installed). So I figured 40GB would be a safe default maximum