### PR TITLE
Fix cups tmpfiles, and move the snippet under desktop profile

### DIFF
--- a/mkosi.extra/usr/lib/tmpfiles.d/etc.conf
+++ b/mkosi.extra/usr/lib/tmpfiles.d/etc.conf
@@ -58,8 +58,6 @@ L? /etc/services
 # Required by nftables service
 L? /etc/nftables.conf
 L? /etc/skel
-# CUPS is pulled in by GNOME, and fails if the configs are not there
-L? /etc/cups
 # On some distributions various binaries in /usr/bin are managed via
 # /etc/alternatives.
 L? /etc/alternatives

--- a/mkosi.profiles/desktop/mkosi.extra/usr/lib/tmpfiles.d/cups.conf
+++ b/mkosi.profiles/desktop/mkosi.extra/usr/lib/tmpfiles.d/cups.conf
@@ -1,0 +1,6 @@
+# CUPS fails if the configs are missing but needs write access in /etc/cups/
+d /etc/cups 0755 root root -
+L? /etc/cups/cupsd.conf
+L? /etc/cups/cups-files.conf
+L? /etc/cups/snmp.conf
+L? /etc/cups/cups-pdf.conf


### PR DESCRIPTION
Cups needs to write in /etc/cups/, but it also needs default files over there or it fails.

Also move the tmpfile snippet under desktop where it makes more sense.

Fixes #170