### PR TITLE
Add 'mount' to mkosi configuration

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -63,6 +63,7 @@ Packages=
         kmod
         less
         man
+        mount
         mtools
         nano
         nftables

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -63,7 +63,6 @@ Packages=
         kmod
         less
         man
-        mount
         mtools
         nano
         nftables

--- a/mkosi.conf.d/arch/mkosi.conf
+++ b/mkosi.conf.d/arch/mkosi.conf
@@ -34,6 +34,7 @@ Packages=
         tgt
         tpm2-tools
         tpm2-tss
+        util-linux
         vim-minimal
         wget
         xz

--- a/mkosi.conf.d/debian/mkosi.conf
+++ b/mkosi.conf.d/debian/mkosi.conf
@@ -35,6 +35,7 @@ Packages=
         locales
         login
         manpages
+        mount
         openssh-client
         openssh-server
         passwd
@@ -59,7 +60,6 @@ Packages=
         systemd-zram-generator
         tpm2-tools
         util-linux-extra
-        mount
         wget
         xz-utils
 

--- a/mkosi.conf.d/debian/mkosi.conf
+++ b/mkosi.conf.d/debian/mkosi.conf
@@ -59,6 +59,7 @@ Packages=
         systemd-zram-generator
         tpm2-tools
         util-linux-extra
+        mount
         wget
         xz-utils
 

--- a/mkosi.conf.d/fedora/mkosi.conf
+++ b/mkosi.conf.d/fedora/mkosi.conf
@@ -52,6 +52,7 @@ Packages=
         systemd-ukify
         tpm2-tools
         tpm2-tss
+        util-linux-core
         veritysetup
         vim-minimal
         wget2


### PR DESCRIPTION
bootctl list is failing because this ParticleOS runtime has no usable /boot mount, so bootctl cannot enumerate the boot entries from the filesystem.