### PR TITLE
Fix factory self-loop symlinks for /etc files not present on all distros

### DIFF
--- a/mkosi.extra/usr/lib/tmpfiles.d/etc.conf
+++ b/mkosi.extra/usr/lib/tmpfiles.d/etc.conf
@@ -37,7 +37,7 @@ L /etc/xdg
 # Contains default font configuration
 L /etc/fonts
 # Configuration for man
-L /etc/man_db.conf
+L? /etc/man_db.conf
 # Configuration for ldconfig
 L /etc/ld.so.conf
 L /etc/ld.so.conf.d

--- a/mkosi.profiles/sway/mkosi.extra/usr/lib/tmpfiles.d/particleos-sway.conf
+++ b/mkosi.profiles/sway/mkosi.extra/usr/lib/tmpfiles.d/particleos-sway.conf
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 # Enable sway and sddm configuration
-L /etc/sddm.conf - - - -
-L /etc/sddm.conf.d - - - -
-L /etc/sddm - - - -
-L /etc/sway - - - -
-L /etc/swaylock - - - -
+L? /etc/sddm.conf - - - -
+L? /etc/sddm.conf.d - - - -
+L? /etc/sddm - - - -
+L? /etc/sway - - - -
+L? /etc/swaylock - - - -


### PR DESCRIPTION
mkosi runs `systemd-tmpfiles --create` during the build, before the mkosi.finalize script captures /etc into /usr/share/factory/etc. An unconditional "L /etc/X - - - -" line for an absent path thus creates the factory symlink prematurely, while the factory is still empty, and mkosi.finalize then archives that symlink into the factory where it points to itself. Resolving such a self-loop fails with ELOOP instead of ENOENT, This made sddm on Debian crash on its config being unreadable.

This affected /etc/sddm.conf, /etc/sddm.conf.d, and /etc/swaylock on Debian, whose sddm and swaylock packages do not ship them, and /etc/man_db.conf since man-db is not part of the Debian image.

Use the tmpfiles "?" modifier, which skips the line while the symlink source does not exist: during the build the factory is not populated yet so no premature symlink is created, and on first boot the link is only created where the factory actually has content. Convert the whole sway snippet rather than just the paths broken on Debian, as other distros may ship a different subset of them.