### PR TITLE
debian: Enable socket activated polkit agent helper

### DIFF
--- a/mkosi.conf.d/debian/mkosi.extra/usr/lib/systemd/system/sockets.target.wants/polkit-agent-helper.socket
+++ b/mkosi.conf.d/debian/mkosi.extra/usr/lib/systemd/system/sockets.target.wants/polkit-agent-helper.socket
@@ -1,0 +1,1 @@
+../polkit-agent-helper.socket


### PR DESCRIPTION
polkitd 127 in Debian no longer ships polkit-agent-helper-1 as setuid root; privilege escalation now happens through the socket activated polkit-agent-helper.socket. Without it, every authentication attempt (run0, GParted, ...) fails with

>  polkit-agent-helper-1: needs to be setuid root

The package enables the socket in /etc through its postinst, but only /usr ships in the image, and /etc is created once at first boot. So on existing installations, and after switching an installation to the Debian image, the socket is never enabled. Ship the enablement symlink in /usr instead, where it is independent of the state of /etc.

This should ideally be done in the package itself: https://bugs.debian.org/1144434