### PR TITLE
Various Debian fixes

### DIFF
--- a/mkosi.conf.d/debian/mkosi.conf.d/x86-64.conf
+++ b/mkosi.conf.d/debian/mkosi.conf.d/x86-64.conf
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Architecture=x86-64
+
+[Content]
+Packages=
+        # signed EFI binary for UEFI capsule updates, which fwupd only
+        # recommends; the package name carries the architecture
+        fwupd-amd64-signed

--- a/mkosi.conf.d/debian/mkosi.extra/usr/lib/systemd/system-preset/20-particleos-debian.preset
+++ b/mkosi.conf.d/debian/mkosi.extra/usr/lib/systemd/system-preset/20-particleos-debian.preset
@@ -2,3 +2,14 @@
 disable apt-daily.timer
 disable apt-daily-upgrade.timer
 disable apt-listchanges.timer
+
+# Debian enables units from the packages' postinst instead of through presets,
+# so preset-all falls back to systemd's "enable" default and switches on a lot
+# more than a Debian installation would have.
+
+# sysv compat dummy unit, fails on every boot without /etc/openvpn
+disable openvpn.service
+# rsync daemon
+disable rsync.service
+# cloud metadata service
+disable systemd-imdsd.socket

--- a/mkosi.conf.d/debian/mkosi.extra/usr/lib/tmpfiles.d/dpkg.conf
+++ b/mkosi.conf.d/debian/mkosi.extra/usr/lib/tmpfiles.d/dpkg.conf
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# Link back the dpkg database which mkosi.finalize moved into the factory, so
+# that queries like "dpkg -l" and "dpkg -S" work. It stays read-only: with /usr
+# on a verity protected image, apt and dpkg cannot install anything anyway.
+L /var/lib/dpkg - - - -

--- a/mkosi.conf.d/debian/mkosi.extra/usr/lib/tmpfiles.d/etc-debian.conf
+++ b/mkosi.conf.d/debian/mkosi.extra/usr/lib/tmpfiles.d/etc-debian.conf
@@ -12,3 +12,8 @@ L? /etc/nftables.conf
 # These can be dropped once https://bugs.debian.org/1108017 is fixed
 L? /etc/adduser.conf
 L? /etc/deluser.conf
+
+# apt's udev rule (61-apt.rules) starts apt-daily.service whenever the machine
+# is plugged into AC, bypassing the disabled apt-daily.timer. It cannot work on
+# a read-only /usr, and fails as neither /etc/apt/ nor /var/lib/apt/ exist.
+L /etc/systemd/system/apt-daily.service - - - - /dev/null

--- a/mkosi.finalize
+++ b/mkosi.finalize
@@ -7,3 +7,11 @@ set -e
 mkdir -p "$BUILDROOT/usr/share/factory/"
 cp --archive --no-target-directory --update=none "$BUILDROOT/etc" "$BUILDROOT/usr/share/factory/etc"
 ln -sr "$BUILDROOT/usr" "$BUILDROOT/usr/share/factory/usr"
+
+# The image only ships /usr, so the dpkg database in /var/lib/ would be lost.
+# Move it to the factory as well, from where tmpfiles symlinks it back to
+# /var/lib/dpkg. On Fedora the rpm database already lives in /usr.
+if [ -d "$BUILDROOT/var/lib/dpkg" ]; then
+    mkdir -p "$BUILDROOT/usr/share/factory/var/lib"
+    mv "$BUILDROOT/var/lib/dpkg" "$BUILDROOT/usr/share/factory/var/lib/dpkg"
+fi

--- a/mkosi.profiles/desktop/mkosi.conf.d/debian/mkosi.conf
+++ b/mkosi.profiles/desktop/mkosi.conf.d/debian/mkosi.conf
@@ -5,6 +5,8 @@ Distribution=debian
 
 [Content]
 Packages=
+        alsa-topology-conf
+        alsa-ucm-conf
         debconf
         desktop-base
         firmware-amd-graphics
@@ -24,7 +26,7 @@ Packages=
         mesa-vulkan-drivers
         modemmanager
         network-manager
-        pipewire-pulse
+        pipewire-audio
         plymouth-themes
         steam-devices
         tuned-ppd

--- a/mkosi.profiles/desktop/mkosi.conf.d/debian/mkosi.conf
+++ b/mkosi.profiles/desktop/mkosi.conf.d/debian/mkosi.conf
@@ -10,6 +10,7 @@ Packages=
         firmware-amd-graphics
         firmware-iwlwifi
         firmware-linux
+        firmware-mediatek
         firmware-sof-signed
         fonts-adobe-sourcesans3
         fonts-noto-color-emoji

--- a/mkosi.profiles/desktop/mkosi.conf.d/debian/mkosi.extra/usr/lib/systemd/user/pipewire-session-manager.service
+++ b/mkosi.profiles/desktop/mkosi.conf.d/debian/mkosi.extra/usr/lib/systemd/user/pipewire-session-manager.service
@@ -1,0 +1,1 @@
+wireplumber.service

--- a/mkosi.profiles/desktop/mkosi.conf.d/debian/mkosi.extra/usr/lib/systemd/user/pipewire.service.wants/wireplumber.service
+++ b/mkosi.profiles/desktop/mkosi.conf.d/debian/mkosi.extra/usr/lib/systemd/user/pipewire.service.wants/wireplumber.service
@@ -1,0 +1,1 @@
+../wireplumber.service

--- a/mkosi.profiles/sway/mkosi.conf.d/debian/mkosi.conf
+++ b/mkosi.profiles/sway/mkosi.conf.d/debian/mkosi.conf
@@ -7,6 +7,7 @@ Distribution=debian
 Packages=
         fonts-font-awesome
         fprintd
+        gnome-keyring
         gvfs-backends
         libpam-gnome-keyring
         thunar


### PR DESCRIPTION
With these (and a few more which are specific to my configuration), plus #181 and #182 I now have a decently working Debian testing POS running on my ThinkPad X13. Judging by how many things were still broken, I believe I'm the only desktop user so far :wink: 

All the "missing Recommends" fixes also tell us something: Debian's Recommends: are really quite strong ("remove it only if you know what you are doing"), so perhaps a better fix would be to simply turn off disabling recommends. I'm happy to do that, LMK.