### PR TITLE
desktop: Install Noto symbol fonts on Debian

### DIFF
--- a/mkosi.profiles/desktop/mkosi.conf.d/debian/mkosi.conf
+++ b/mkosi.profiles/desktop/mkosi.conf.d/debian/mkosi.conf
@@ -16,6 +16,7 @@ Packages=
         firmware-sof-signed
         fonts-adobe-sourcesans3
         fonts-noto-color-emoji
+        fonts-noto-core
         fonts-noto-mono
         gstreamer1.0-libav
         gstreamer1.0-plugins-ugly


### PR DESCRIPTION
The Debian profile misses the symbol blocks covered by fonts-noto-core. Fedora and Arch profiles install google-noto-fonts-all and noto-fonts, which both both ship NotoSansSymbols and NotoSansSymbols2.