### PR TITLE
Enable greeters, starting after first-boot-complete.target

### DIFF
--- a/mkosi.extra/usr/lib/systemd/system-preset/10-particleos.preset
+++ b/mkosi.extra/usr/lib/systemd/system-preset/10-particleos.preset
@@ -24,8 +24,8 @@ enable power-profiles-daemon.service
 # Our own service to run systemctl preset --global.
 enable preset-global.service
 
-# Should be enabled manually by the user after first boot.
-disable gdm.service
+enable gdm.service
+enable sddm.service
 
 # Prefer socket activated SSH over daemon SSH
 disable sshd.service

--- a/mkosi.extra/usr/lib/systemd/system/display-manager.service.d/10-particleos.conf
+++ b/mkosi.extra/usr/lib/systemd/system/display-manager.service.d/10-particleos.conf
@@ -1,0 +1,2 @@
+[Unit]
+After=first-boot-complete.target

--- a/mkosi.uki-profiles/20-install.conf
+++ b/mkosi.uki-profiles/20-install.conf
@@ -12,6 +12,7 @@ Cmdline=
         systemd.mask=systemd-repart.service
         systemd.unit=system-install.target
         systemd.set-credential=passwd.plaintext-password.root:particleos
+        systemd.mask=display-manager.service
         rw
         audit=0
         systemd.image_policy=esp=unprotected:xbootldr=unprotected+unused+absent:usr=signed:=ignore


### PR DESCRIPTION
See #87 which was initially merged and then reverted because starting the greeter broke the installer profile.

This new version adds a `systemd.mask=display-manager.service` parameter to the installer profile's kernel command line. That's the only difference compared to the previous PR.

I took a look at the other profiles to see if it'd be necessary in any of them. Nothing else seemed necessary.