### PR TITLE
fedora: Add riscv64 image configuration

### DIFF
--- a/mkosi.conf.d/fedora/mkosi.conf.d/riscv64.conf
+++ b/mkosi.conf.d/fedora/mkosi.conf.d/riscv64.conf
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Architecture=riscv64
+
+[Config]
+MinimumVersion=commit:0808f37d8c9d74c337b341f6b519279b74a0bccf
+
+[Distribution]
+# Fedora RISC-V rawhide can lag behind the stable release repositories.
+Release=44
+
+[Validation]
+# Fedora's RISC-V firmware does not provide measured-boot PCRs yet.
+SignExpectedPcr=no
+
+[Runtime]
+# QEMU exposes its RISC-V TPM through the device tree rather than ACPI.
+TPM=yes
+QemuArgs=
+    -device
+    tpm-tis-device,tpmdev=tpm0
+    -machine
+    acpi=off


### PR DESCRIPTION
## Summary

Add Fedora 44 `riscv64` support for ParticleOS.

- Select Fedora 44 only for `riscv64`; Fedora `x86-64` remains on Rawhide.
- Require systemd/mkosi#4450 commit
  `0808f37d8c9d74c337b341f6b519279b74a0bccf` only for `riscv64`; all other
  architectures retain the packaged-mkosi-compatible `MinimumVersion=26~devel`.
- Expose QEMU's software TPM through the RISC-V device tree with
  `tpm-tis-device` and `acpi=off`.
- Disable expected-PCR signing on RISC-V because Fedora's RISC-V EDK2 firmware
  does not initialize measured-boot PCRs.
- Use the default systemd device and service timeouts.

TPM-backed root and swap encryption, Secure Boot signing, the signed UKI, and
dm-verity-protected `/usr` remain enabled.

## Validation

Validated with systemd/mkosi at
`0808f37d8c9d74c337b341f6b519279b74a0bccf`:

- `mkosi summary` resolves Fedora `riscv64` to Fedora 44, the required commit
  minimum, a disk image, Secure Boot enabled, expected-PCR signing disabled,
  and the intended TPM/QEMU device-tree settings.
- The equivalent Fedora `x86-64` configuration resolves to Rawhide with
  `MinimumVersion=26~devel`, expected-PCR signing enabled, TPM auto-detection,
  and no commit pin or RISC-V QEMU arguments.
- `mkosi -B -f` builds the complete signed and verity-protected image.
- `mkosi vm` discovers `/dev/tpm0`, completes `systemd-repart`, unlocks the
  TPM-encrypted root and swap volumes, mounts verity-protected `/usr`, reaches
  `network-online.target` and `multi-user.target`, and permits serial login.
- The final runtime configuration was rebuilt and booted after removing the
  timeout overrides; the encrypted `systemd-homed` account was active and login
  succeeded with the default systemd timeouts.
- The dependency-scoping cleanup changes no effective RISC-V runtime settings,
  so it was revalidated with resolved configuration checks rather than another
  full VM boot.
- `git diff --check` passes.

The only failed unit was `authselect-apply-changes.service`. The same failure
reproduces on Fedora x86-64, so it is tracked separately as a Fedora-wide issue.
This PR does not change authselect, and the failure did not block networking,
login, or `multi-user.target`.

## Dependency

RISC-V support depends on systemd/mkosi#4450. The RISC-V-only pin currently
names a commit in that PR's history. If upstream rebases or squash-merges the
PR, update `MinimumVersion=` to a reachable landed commit before merging this
PR.

## AI assistance

GitHub Copilot was used to develop, debug, review, and validate this change.
